### PR TITLE
chore: switch deployment references from Vercel to Netlify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  deployments: write
+
 jobs:
   create-deployment:
     runs-on: ubuntu-latest
@@ -22,9 +26,10 @@ jobs:
           fi
 
       - name: Create deployment
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           gh api repos/${{ github.repository }}/deployments \
-            -f ref="${{ github.head_ref || github.ref }}" \
+            -f ref="${{ github.event.pull_request.head.sha || github.sha }}" \
             -f environment="${{ steps.vars.outputs.environment }}" \
             -f transient_environment=false \
             -f production_environment="${{ steps.vars.outputs.environment == 'Production' }}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,8 @@
-name: Register Netlify deployment
+name: Register Netlify deployment links
+
+# Netlify does the real deploys.
+# This workflow only adds Netlify URLs to GitHub's deployment UI.
+# Status is not synced with Netlify by design.
 
 on:
   push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   register-production:
     if: github.event_name == 'push'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - run: echo "Registered Netlify production deployment in GitHub"
 
   register-preview:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment:
       name: preview

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy (Netlify)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  create-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set environment and URL
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "environment=Production" >> "$GITHUB_OUTPUT"
+            echo "url=https://foosly.netlify.app" >> "$GITHUB_OUTPUT"
+          else
+            echo "environment=Preview" >> "$GITHUB_OUTPUT"
+            echo "url=https://deploy-preview-${{ github.event.number }}--foosly.netlify.app" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create deployment
+        run: |
+          gh api repos/${{ github.repository }}/deployments \
+            -f ref="${{ github.head_ref || github.ref }}" \
+            -f environment="${{ steps.vars.outputs.environment }}" \
+            -f transient_environment=false \
+            -f production_environment="${{ steps.vars.outputs.environment == 'Production' }}" \
+            -f auto_merge=false \
+            > /tmp/deployment.json
+
+          DEPLOY_ID=$(jq -r '.id' /tmp/deployment.json)
+          echo "deployment_id=$DEPLOY_ID" >> "$GITHUB_OUTPUT"
+
+          gh api repos/${{ github.repository }}/deployments/$DEPLOY_ID/statuses \
+            -f state=success \
+            -f environment="${{ steps.vars.outputs.environment }}" \
+            -f environment_url="${{ steps.vars.outputs.url }}" \
+            -f log_url="${{ steps.vars.outputs.url }}" \
+            -f description="Deployed via Netlify"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,51 +1,26 @@
-name: Deploy (Netlify)
+name: Register Netlify deployment
 
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
-
-permissions:
-  contents: read
-  deployments: write
+    types: [opened, synchronize, reopened]
 
 jobs:
-  create-deployment:
+  register-production:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://foosly.netlify.app
     steps:
-      - name: Set environment and URL
-        id: vars
-        run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "environment=Production" >> "$GITHUB_OUTPUT"
-            echo "url=https://foosly.netlify.app" >> "$GITHUB_OUTPUT"
-          else
-            echo "environment=Preview" >> "$GITHUB_OUTPUT"
-            echo "url=https://deploy-preview-${{ github.event.number }}--foosly.netlify.app" >> "$GITHUB_OUTPUT"
-          fi
+      - run: echo "Registered Netlify production deployment in GitHub"
 
-      - name: Create deployment
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        run: |
-          gh api repos/${{ github.repository }}/deployments \
-            -f ref="${{ github.event.pull_request.head.sha || github.sha }}" \
-            -f environment="${{ steps.vars.outputs.environment }}" \
-            -f transient_environment=false \
-            -f production_environment="${{ steps.vars.outputs.environment == 'Production' }}" \
-            -f auto_merge=false \
-            -f required_contexts[]= \
-            > /tmp/deployment.json
-
-          DEPLOY_ID=$(jq -r '.id' /tmp/deployment.json)
-          echo "deployment_id=$DEPLOY_ID" >> "$GITHUB_OUTPUT"
-
-          gh api repos/${{ github.repository }}/deployments/$DEPLOY_ID/statuses \
-            -f state=in_progress \
-            -f environment="${{ steps.vars.outputs.environment }}" \
-            -f environment_url="${{ steps.vars.outputs.url }}" \
-            -f log_url="${{ steps.vars.outputs.url }}" \
-            -f description="Deploying via Netlify (check Netlify status for final result)"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: deploy
+  register-preview:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: preview
+      url: https://deploy-preview-${{ github.event.pull_request.number }}--foosly.netlify.app
+    steps:
+      - run: echo "Registered Netlify preview deployment in GitHub"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,11 +40,11 @@ jobs:
           echo "deployment_id=$DEPLOY_ID" >> "$GITHUB_OUTPUT"
 
           gh api repos/${{ github.repository }}/deployments/$DEPLOY_ID/statuses \
-            -f state=success \
+            -f state=in_progress \
             -f environment="${{ steps.vars.outputs.environment }}" \
             -f environment_url="${{ steps.vars.outputs.url }}" \
             -f log_url="${{ steps.vars.outputs.url }}" \
-            -f description="Deployed via Netlify"
+            -f description="Deploying via Netlify (check Netlify status for final result)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,7 @@ jobs:
             -f transient_environment=false \
             -f production_environment="${{ steps.vars.outputs.environment == 'Production' }}" \
             -f auto_merge=false \
+            -f required_contexts[]= \
             > /tmp/deployment.json
 
           DEPLOY_ID=$(jq -r '.id' /tmp/deployment.json)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,11 @@ We're excited to have you contribute! To keep things organized and maintain code
     - **Test Locally:** Please make sure your changes work correctly and don't break anything else by testing the application locally on your computer _before_ you push your code.
     - **Run Formatter:** Format your code using Prettier by running this command in your terminal:
       ```bash
-      npm run format
+      pnpm format
       ```
     - **Run Linter:** Check and automatically fix any linting issues using ESLint by running this command:
       ```bash
-      npm run lint
+      pnpm lint
       ```
     - Commit any changes made by the formatter or linter.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,12 @@ src/
 
 ## Deployment
 
-Built using Vite's optimized production build. Environment variables should be configured on the production deployment
+Deployed on [Netlify](https://www.netlify.com/) with continuous deployment from the `main` branch.
+
+- **Production**: [foosly.netlify.app](https://foosly.netlify.app)
+- **Preview**: Automatic deploy previews for every pull request (e.g., `deploy-preview-{PR_NUMBER}--foosly.netlify.app`)
+
+Build settings are configured in [`netlify.toml`](./netlify.toml). Environment variables are managed in the Netlify dashboard.
 
 ## Running Without Supabase
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "pnpm run build"
+  publish = "dist"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Summary

Updates all references from Vercel to Netlify, the current deployment provider.

### Changes

- **README.md**: Updated Deployment section with Netlify URLs (production + deploy previews)
- **netlify.toml**: Added build configuration with ,  publish dir, and SPA redirect rules
- **.github/workflows/deploy.yml**: New workflow that creates GitHub Deployment records for Netlify deploys (shows up under the [Deployments](https://github.com/foosball-tracker/foosball-tracker/deployments) tab)
- **CONTRIBUTING.md**: Fixed commands from `npm` to `pnpm`
- **GitHub repo settings**: Updated homepage URL to `https://foosly.netlify.app`
- **Old Vercel deployments**: Marked all 30 legacy Vercel deployments as inactive