### PR TITLE
feat: refine main screen theming (#11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,9 @@ Important rules:
 - Prefer small focused changes over broad refactors.
 - Keep Supabase-related changes typed and centralized in `src/service`.
 - Preserve the existing service/store split instead of moving data access into components.
-- For UI changes, follow [`docs/ai-ui-workflow.md`](./docs/ai-ui-workflow.md) and verify both desktop and mobile layouts.
+- For UI changes, follow [`docs/ai-ui-workflow.md`](./docs/ai-ui-workflow.md) exactly.
+- For UI changes, verify both desktop and mobile layouts.
+- For UI changes, publish PR proof screenshots with `npx pnpm@10 proof:capture` and `npx pnpm@10 proof:publish`, then verify the PR comment links render correctly before the PR is ready for review.
 - Run lint and build before opening a PR.
 - Avoid editing generated types manually unless the generation flow is broken.
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -41,11 +41,8 @@ git checkout -b feat/16-team-management-crud
    npx pnpm@10 dev
    ```
 3. If the change touches UI, verify the browser workflow first:
-   ```bash
-   opencode mcp list
-   ```
-   Confirm `playwright` is connected, then follow [`docs/ai-ui-workflow.md`](./docs/ai-ui-workflow.md).
-   Use `npx pnpm@10 ui:inspect:start` for manual inspection rather than backgrounding `pnpm dev`. This keeps agent-driven UI work on `4174` instead of colliding with normal local dev on `5173`.
+   Follow [`docs/ai-ui-workflow.md`](./docs/ai-ui-workflow.md) from start to finish.
+   This includes Playwright inspection, desktop/mobile verification, proof capture, and proof publication back to the PR.
 4. Implement the feature. Follow the guidelines in `AGENTS.md` (SolidJS patterns, service/store split, etc.).
 
 ---
@@ -92,6 +89,15 @@ npx pnpm@10 build       # TypeScript + Vite build
 
 All three must pass before pushing.
 
+If the change touches UI, also complete the proof flow before pushing or before marking the PR ready:
+
+```bash
+npx pnpm@10 proof:capture -- --name <descriptive-name> --route <route>
+npx pnpm@10 proof:publish
+```
+
+Then verify the PR comment contains working screenshot previews and direct links.
+
 ---
 
 ## 7. Commit and Push
@@ -123,6 +129,13 @@ Closes #16
 If later pushes introduce larger new behavior, migrations, workflow changes, or other meaningful scope changes, update the PR description so it still matches the actual contents of the branch.
 Small follow-up fixes do not need a PR description update unless they materially change scope or rollout considerations.
 
+For UI changes:
+
+1. Open the PR as a draft first.
+2. Publish local proof screenshots to the PR.
+3. Verify the Netlify preview and the screenshot proof comment.
+4. Only then mark the PR ready for review.
+
 ---
 
 ## 9. Automated Deploys & Checks
@@ -132,6 +145,7 @@ Small follow-up fixes do not need a PR description update unless they materially
 - Netlify auto-builds a deploy preview for every PR.
 - The preview URL is posted as a comment by the Netlify bot (e.g. `https://deploy-preview-28--foosly.netlify.app`).
 - **Test the preview on mobile** — the deploy preview is the closest thing to production.
+- For UI PRs, do not rely on Netlify alone. Local proof screenshots published from `proof:publish` are also required.
 
 ### Supabase Preview Branch
 
@@ -154,6 +168,7 @@ Small follow-up fixes do not need a PR description update unless they materially
   (Post this as a PR comment.)
 - After pushing a fix for a specific review thread, check whether GitHub auto-resolved it.
 - If the thread or comment is still open even though the fix is in the branch, manually resolve that specific thread so the PR reflects the real review state.
+- Before marking the PR ready, confirm there are no unresolved Codex review threads that still apply.
 
 ### Human Review
 
@@ -186,6 +201,12 @@ Check the results with the SonarQube MCP:
    ```
 
 Fix any issues that block the quality gate or are significant. Ignore issues in generated files (e.g. `src/types/database.ts`) unless the generation flow is broken.
+
+Before marking the PR ready, confirm:
+
+- Quality gate is passing.
+- There are no meaningful open Sonar issues left unaddressed.
+- There are no open security hotspots for the PR.
 
 ---
 

--- a/docs/ai-ui-workflow.md
+++ b/docs/ai-ui-workflow.md
@@ -1,103 +1,93 @@
-# AI UI Inspection Workflow
+# AI UI Workflow
 
-## Starting the app
+Use this exact flow for every UI change.
 
-```sh
-npx pnpm@10 ui:inspect:start
-```
+## Happy Path
 
-The inspection server runs at **http://localhost:4174**.
-
-For routine local development, `npx pnpm@10 dev` still uses Vite's default port (`5173`).
-Keep that separate from UI inspection so agent tooling does not collide with a manually started dev server.
-
-## Playwright MCP
-
-Playwright MCP is configured in `opencode.jsonc` and `.codex/config.toml`. Both Codex and OpenCode use `.codex/playwright-mcp-launcher.mjs`, which resolves the locally installed Chromium path from the `playwright` package at runtime instead of hardcoding a cache version.
-
-The MCP runs headless in isolated mode so each session starts clean.
-
-- **Desktop viewport**: 1280×720 (default)
-- **Mobile viewport**: use `--viewport` flag or resize via tool commands to 375×812
-
-Agent must inspect both desktop and mobile layouts for every UI change.
-
-## Authenticated browser inspection
-
-The MCP browser starts each session clean. To inspect pages that require authentication:
-
-1. Ensure `playwright/.auth/user.json` exists (run `pnpm auth:local` if not).
-2. Use `pnpm proof:capture` to capture authenticated screenshots with descriptive names:
+1. Run automated UI coverage first:
    ```sh
-   pnpm proof:capture -- --name header-before --route /
+   npx pnpm@10 test:e2e
    ```
-   Screenshots are saved to `e2e/screenshots/<branch-name>/` as `<name>-desktop.png` and `<name>-mobile.png`.
-3. Publish the local proof set back to the open PR:
+2. Start the dedicated inspection server:
    ```sh
-   pnpm proof:publish
+   npx pnpm@10 ui:inspect:start
    ```
-   This uploads every PNG under `e2e/screenshots/<branch-name>/` and refreshes the PR comment with inline previews.
-4. Or run `pnpm test:e2e` to execute authenticated tests. Playwright uses the same dedicated fixed port, `4174`, so the saved auth state and manual inspection stay on the same origin.
-
-## Preferred order
-
-1. Run `npx pnpm@10 test:e2e` first.
-2. If you need manual browser inspection, start `npx pnpm@10 ui:inspect:start`.
-3. When finished with manual inspection, stop it with:
+3. Inspect the changed route in Playwright MCP at both viewports:
+   - Desktop: `1280x720`
+   - Mobile: `375x812`
+4. Capture proof screenshots with descriptive names:
+   ```sh
+   npx pnpm@10 proof:capture -- --name header-before --route /
+   npx pnpm@10 proof:capture -- --name header-after --route /
+   ```
+5. Publish the proof set back to the open PR:
+   ```sh
+   npx pnpm@10 proof:publish
+   ```
+6. Open the PR comment and confirm the screenshot previews and direct links work.
+7. Run the final checks:
+   ```sh
+   npx pnpm@10 format:check
+   npx pnpm@10 lint
+   npx pnpm@10 build
+   ```
+8. Stop the inspection server when done:
    ```sh
    npx pnpm@10 ui:inspect:stop
    ```
 
-Do not start `pnpm dev` in the background with `&` from an agent shell tool. Shell timeouts can tear down the parent process and leave the port state ambiguous.
+## Required Checks
 
-## Verify the MCP before UI work
+Every UI change must be checked for:
 
-1. Confirm Chromium is installed locally:
+1. Before/after screenshots
+2. Desktop layout
+3. Mobile layout
+4. Console errors
+5. Failed network requests
+6. Horizontal overflow or clipping
+7. Loading states
+8. Empty states
+9. Error states
+
+## Commands
+
+Inspection server:
 
 ```sh
-npx playwright install chromium
+npx pnpm@10 ui:inspect:start
+npx pnpm@10 ui:inspect:status
+npx pnpm@10 ui:inspect:stop
 ```
 
-2. Confirm OpenCode sees the server:
+Proof capture and publish:
 
 ```sh
-opencode mcp list
+npx pnpm@10 proof:capture -- --name <name> --route <route>
+npx pnpm@10 proof:publish
 ```
 
-You should see `playwright` with status `connected`.
+Authenticated local browser state:
 
-3. If you changed `opencode.jsonc` or `.codex/config.toml`, restart the agent session before testing again. Local MCP server config is not hot-reloaded reliably mid-session.
+```sh
+npx pnpm@10 auth:local
+```
+
+## Output Locations
+
+- Local screenshots: `e2e/screenshots/<branch-name>/`
+- Published proof branch: `pr-proof-assets`
+- PR proof comment: updated by `proof:publish`
+
+## Rules
+
+- Do not skip proof publishing for UI PRs.
+- Do not mark a UI PR ready for review until the screenshot comment is published and verified.
+- Do not use ad hoc screenshot scripts when `proof:capture` and `proof:publish` are available.
+- Do not use `pnpm dev` as the inspection server. Use `ui:inspect:start`.
 
 ## Troubleshooting
 
-- If Playwright fails with a missing Chrome or Chromium binary, rerun `npx playwright install chromium`.
-- If the configured browser path changed after a Playwright browser update, do not hardcode the new cache directory. Keep using `.codex/playwright-mcp-launcher.mjs`.
-- If the MCP was broken in a previous session, restart the session after fixing config instead of trying to revive stale server processes manually.
-- Prefer MCP browser tools over ad hoc root-level helper scripts for routine UI inspection.
-- `pnpm ui:inspect:start` fails fast if port `4174` is occupied by some other process. Resolve that conflict instead of letting Vite drift to another port.
-- `pnpm test:e2e` uses strict port `4174`. If that port is occupied, fix the conflict rather than reusing an unknown server.
-- Local agent screenshots are the primary PR proof. Publish them with `pnpm proof:publish`, which copies them to the `pr-proof-assets` branch so GitHub comments can render inline previews.
-
-## Checklist for every UI change
-
-1. **Screenshots** — take before/after screenshots at desktop and mobile widths
-2. **Console errors** — verify no JS errors in the browser console
-3. **Network errors** — check for failed requests (4xx/5xx)
-4. **Overflow** — look for horizontal scroll or clipped content
-5. **Spacing** — verify padding, margins, and alignment match the Figma design
-6. **Loading states** — confirm skeleton/spinner renders while data loads
-7. **Empty states** — confirm friendly message when no data exists
-8. **Error states** — confirm graceful handling of failed API calls
-
-## Before finishing
-
-```sh
-npx pnpm@10 lint
-npx pnpm@10 build
-```
-
-Fix any lint or type errors before submitting.
-
-## Gitignore
-
-Screenshots, browser caches, auth state, and test artifacts are excluded via `.gitignore`. Never commit `*.png`, `*.webm`, `test-results/`, `.playwright-mcp/`, or `playwright-auth.json`.
+- If Playwright auth state is missing, run `npx pnpm@10 auth:local`.
+- If the inspection server port is occupied, fix the port conflict instead of changing the port.
+- If published screenshot links are broken, rerun `proof:publish` and verify `pr-proof-assets` contains `pr-<number>/local/latest/*.png`.

--- a/scripts/proof-publish.mjs
+++ b/scripts/proof-publish.mjs
@@ -88,9 +88,7 @@ let commentUrl = "";
 try {
   let hasRemoteBranch = true;
   try {
-    run("git", ["ls-remote", "--exit-code", "--heads", "origin", PROOF_BRANCH], {
-      stdio: "ignore",
-    });
+    run("git", ["ls-remote", "--exit-code", "--heads", "origin", PROOF_BRANCH]);
   } catch {
     hasRemoteBranch = false;
   }
@@ -102,6 +100,11 @@ try {
   } else {
     run("git", ["worktree", "add", "--detach", worktreeDir]);
     run("git", ["checkout", "--orphan", PROOF_BRANCH], { cwd: worktreeDir });
+
+    for (const entry of readdirSync(worktreeDir, { withFileTypes: true })) {
+      if (entry.name === ".git") continue;
+      rmSync(join(worktreeDir, entry.name), { recursive: true, force: true });
+    }
   }
 
   const targetDir = join(worktreeDir, publishDir);
@@ -117,14 +120,9 @@ try {
 
   run("git", ["config", "user.name", "Joshua Lehmann"], { cwd: worktreeDir });
   run("git", ["config", "user.email", "joshua.le1999@gmail.com"], { cwd: worktreeDir });
-  run("git", ["add", publishDir], { cwd: worktreeDir });
+  run("git", ["add", "-f", publishDir], { cwd: worktreeDir });
 
-  let worktreeHasChanges = false;
-  try {
-    run("git", ["diff", "--cached", "--quiet"], { cwd: worktreeDir, stdio: "ignore" });
-  } catch {
-    worktreeHasChanges = true;
-  }
+  const worktreeHasChanges = run("git", ["status", "--short"], { cwd: worktreeDir }).length > 0;
 
   if (worktreeHasChanges) {
     run("git", ["commit", "-m", `chore: update PR ${pr.number} local proof screenshots`], {
@@ -133,7 +131,7 @@ try {
     run("git", ["push", "origin", `HEAD:${PROOF_BRANCH}`], { cwd: worktreeDir });
   }
 
-  const rawBase = `https://raw.githubusercontent.com/${repo}/${PROOF_BRANCH}/${publishDir}`;
+  const rawBase = `https://github.com/${repo}/raw/${PROOF_BRANCH}/${publishDir}`;
   const blobBase = `https://github.com/${repo}/blob/${PROOF_BRANCH}/${publishDir}`;
   const previewLines = screenshots.map(
     ({ label, destName }) => `- [${label}](${blobBase}/${destName})`

--- a/scripts/proof-publish.mjs
+++ b/scripts/proof-publish.mjs
@@ -100,11 +100,8 @@ try {
   } else {
     run("git", ["worktree", "add", "--detach", worktreeDir]);
     run("git", ["checkout", "--orphan", PROOF_BRANCH], { cwd: worktreeDir });
-
-    for (const entry of readdirSync(worktreeDir, { withFileTypes: true })) {
-      if (entry.name === ".git") continue;
-      rmSync(join(worktreeDir, entry.name), { recursive: true, force: true });
-    }
+    run("git", ["rm", "-rf", "--ignore-unmatch", "."], { cwd: worktreeDir });
+    run("git", ["clean", "-fdx"], { cwd: worktreeDir });
   }
 
   const targetDir = join(worktreeDir, publishDir);

--- a/src/App.css
+++ b/src/App.css
@@ -4,6 +4,6 @@
 
 @plugin "daisyui" {
   themes:
-    light --default,
-    night --prefersdark;
+    winter --default,
+    dim --prefersdark;
 }

--- a/src/components/GoalHistory.tsx
+++ b/src/components/GoalHistory.tsx
@@ -14,7 +14,7 @@ export function GoalHistory(props: Readonly<GoalHistoryProps>) {
   };
 
   return (
-    <div class="card card-bordered bg-base-300 max-w-3xl">
+    <div class="card card-bordered border-base-300 bg-base-100 max-w-3xl shadow-sm">
       <div class="card-body">
         <h2 class="card-title">Goal History</h2>
         {/* Timeline container */}
@@ -27,7 +27,7 @@ export function GoalHistory(props: Readonly<GoalHistoryProps>) {
                 <div class="relative mb-3 flex items-center space-x-4 pl-6">
                   {/* Timeline marker */}
                   <div
-                    class={`absolute -left-6 h-3 w-3 ${dotColor} border-base-300 top-1/2 -translate-y-1/2 transform rounded-full border-2`}
+                    class={`absolute -left-6 h-3 w-3 ${dotColor} border-base-100 top-1/2 -translate-y-1/2 transform rounded-full border-2`}
                   />
                   {/* Team name in fixed width for alignment */}
                   <span class="w-64 truncate font-semibold">

--- a/src/components/ProtectedApp.tsx
+++ b/src/components/ProtectedApp.tsx
@@ -13,7 +13,7 @@ export default function ProtectedApp() {
   });
 
   return (
-    <div class="flex h-full flex-col p-4">
+    <div class="bg-base-200 flex h-full flex-col p-3 sm:p-4">
       <div class="flex flex-wrap gap-4">
         <div class="flex min-w-[250px] flex-1 flex-col gap-4">
           <ScoreBoard settings={settings} />

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -119,7 +119,7 @@ export function ScoreBoard(props: Readonly<ScoreBoardProps>) {
   });
 
   return (
-    <div class="card card-border bg-base-300 max-w-3xl">
+    <div class="card card-border border-base-300 bg-base-100 max-w-3xl shadow-sm">
       <div class="card-body">
         <div class="flex items-center justify-between">
           <h2 class="card-title text-2xl">Score</h2>
@@ -129,7 +129,7 @@ export function ScoreBoard(props: Readonly<ScoreBoardProps>) {
                 Start Game
               </button>
             )}
-            <button class="btn btn-sm btn-error" onClick={resetScores}>
+            <button class="btn btn-sm btn-soft btn-error" onClick={resetScores}>
               Reset Game
             </button>
           </div>

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -121,15 +121,15 @@ export function ScoreBoard(props: Readonly<ScoreBoardProps>) {
   return (
     <div class="card card-border border-base-300 bg-base-100 max-w-3xl shadow-sm">
       <div class="card-body">
-        <div class="flex items-center justify-between">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h2 class="card-title text-2xl">Score</h2>
-          <div class="flex gap-2">
+          <div class="flex flex-wrap justify-end gap-2">
             {!gameState.gameRunning && (
-              <button class="btn btn-sm btn-primary" onClick={startGame}>
+              <button class="btn btn-primary btn-sm sm:btn-md min-w-28" onClick={startGame}>
                 Start Game
               </button>
             )}
-            <button class="btn btn-sm btn-soft btn-error" onClick={resetScores}>
+            <button class="btn btn-soft btn-error btn-sm sm:btn-md min-w-28" onClick={resetScores}>
               Reset Game
             </button>
           </div>

--- a/src/components/ScoreButton.tsx
+++ b/src/components/ScoreButton.tsx
@@ -13,7 +13,7 @@ export function ScoreButton(props: Readonly<ScoreButtonProps>): JSX.Element {
 
   return (
     <button
-      class={`btn btn-circle ${props.direction === -1 ? "btn-error" : "btn-primary"}`}
+      class={`btn btn-circle ${props.direction === -1 ? "btn-soft" : "btn-primary"}`}
       disabled={!gameState.gameRunning}
       onClick={handleClick}
     >

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -12,7 +12,7 @@ export interface SettingsProps {
 // The parent renders the card and header immediately.
 export function Settings(props: Readonly<SettingsProps>) {
   return (
-    <div class="card card-border bg-base-300">
+    <div class="card card-border border-base-300 bg-base-100 shadow-sm">
       <div class="card-body">
         <h2 class="card-title text-2xl">Settings</h2>
         {/* Only the content that needs the resource is wrapped in Suspense */}

--- a/src/components/ThemeSwitch.tsx
+++ b/src/components/ThemeSwitch.tsx
@@ -15,13 +15,14 @@ export function ThemeSwitch() {
 
   onMount(() => {
     const storedTheme = localStorage.getItem(STORAGE_KEY);
-    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const initialTheme =
-      storedTheme === LIGHT_THEME || storedTheme === DARK_THEME
-        ? storedTheme
-        : prefersDark
-          ? DARK_THEME
-          : LIGHT_THEME;
+    const prefersDark = globalThis.matchMedia("(prefers-color-scheme: dark)").matches;
+    let initialTheme = LIGHT_THEME;
+
+    if (storedTheme === LIGHT_THEME || storedTheme === DARK_THEME) {
+      initialTheme = storedTheme;
+    } else if (prefersDark) {
+      initialTheme = DARK_THEME;
+    }
 
     applyTheme(initialTheme);
   });

--- a/src/components/ThemeSwitch.tsx
+++ b/src/components/ThemeSwitch.tsx
@@ -2,7 +2,7 @@ export function ThemeSwitch() {
   return (
     <>
       <label class="swap swap-rotate">
-        <input type="checkbox" class="theme-controller" value="light" />
+        <input type="checkbox" class="theme-controller" value="winter" />
 
         <svg
           class="swap-off h-8 w-8 fill-current"

--- a/src/components/ThemeSwitch.tsx
+++ b/src/components/ThemeSwitch.tsx
@@ -5,7 +5,7 @@ export function ThemeSwitch() {
         <input type="checkbox" class="theme-controller" value="winter" />
 
         <svg
-          class="swap-off h-8 w-8 fill-current"
+          class="swap-off h-6 w-6 fill-current sm:h-8 sm:w-8"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
         >
@@ -13,7 +13,7 @@ export function ThemeSwitch() {
         </svg>
 
         <svg
-          class="swap-on h-8 w-8 fill-current"
+          class="swap-on h-6 w-6 fill-current sm:h-8 sm:w-8"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
         >

--- a/src/components/ThemeSwitch.tsx
+++ b/src/components/ThemeSwitch.tsx
@@ -1,8 +1,39 @@
+import { createSignal, onMount } from "solid-js";
+
+const LIGHT_THEME = "winter";
+const DARK_THEME = "dim";
+const STORAGE_KEY = "theme";
+
 export function ThemeSwitch() {
+  const [isLightTheme, setIsLightTheme] = createSignal(true);
+
+  const applyTheme = (theme: string) => {
+    document.documentElement.dataset.theme = theme;
+    localStorage.setItem(STORAGE_KEY, theme);
+    setIsLightTheme(theme === LIGHT_THEME);
+  };
+
+  onMount(() => {
+    const storedTheme = localStorage.getItem(STORAGE_KEY);
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const initialTheme =
+      storedTheme === LIGHT_THEME || storedTheme === DARK_THEME
+        ? storedTheme
+        : prefersDark
+          ? DARK_THEME
+          : LIGHT_THEME;
+
+    applyTheme(initialTheme);
+  });
+
   return (
     <>
       <label class="swap swap-rotate">
-        <input type="checkbox" class="theme-controller" value="winter" />
+        <input
+          type="checkbox"
+          checked={isLightTheme()}
+          onInput={(event) => applyTheme(event.currentTarget.checked ? LIGHT_THEME : DARK_THEME)}
+        />
 
         <svg
           class="swap-off h-6 w-6 fill-current sm:h-8 sm:w-8"

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -58,7 +58,7 @@ export function Login() {
       fallback={
         <div class="flex min-w-0 items-center gap-2">
           <p class="hidden max-w-40 truncate text-sm sm:block">{session()?.user.email}</p>
-          <button class="btn btn-ghost btn-sm sm:btn-md" onClick={signOut}>
+          <button class="btn btn-ghost btn-sm sm:btn-md px-3" onClick={signOut}>
             Logout
           </button>
         </div>
@@ -69,7 +69,7 @@ export function Login() {
         fallback={<span class="text-base-content/60 text-sm">Sign in unavailable</span>}
       >
         <button
-          class="btn btn-outline btn-sm sm:btn-md"
+          class="btn btn-outline btn-sm sm:btn-md px-3"
           onClick={() => {
             const modal = document.getElementById("login-modal");
             if (modal instanceof HTMLDialogElement) {
@@ -95,7 +95,7 @@ export function Login() {
             />
             <div class="modal-action">
               <form method="dialog">
-                <button class="btn">Close</button>
+                <button class="btn btn-ghost btn-sm sm:btn-md">Close</button>
               </form>
             </div>
           </div>

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -10,6 +10,8 @@ export function Login() {
   const [isDarkAuthTheme, setIsDarkAuthTheme] = createSignal(false);
 
   onMount(() => {
+    let subscriptionCleanup: (() => void) | undefined;
+
     const html = document.documentElement;
     const updateAuthTheme = () => {
       setIsDarkAuthTheme(html.dataset.theme === "dim");
@@ -25,8 +27,6 @@ export function Login() {
     });
 
     if (!hasSupabaseConfig()) return;
-
-    let subscriptionCleanup: () => void;
 
     (async () => {
       const {

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -7,15 +7,26 @@ import { getRedirectUrl } from "~/components/auth/authHelper.ts";
 
 export function Login() {
   const [session, setSession] = createSignal<Session | null>(null);
+  const [isDarkAuthTheme, setIsDarkAuthTheme] = createSignal(false);
 
   onMount(() => {
+    const html = document.documentElement;
+    const updateAuthTheme = () => {
+      setIsDarkAuthTheme(html.getAttribute("data-theme") === "dim");
+    };
+    updateAuthTheme();
+
+    const themeObserver = new MutationObserver(updateAuthTheme);
+    themeObserver.observe(html, { attributes: true, attributeFilter: ["data-theme"] });
+
+    onCleanup(() => {
+      themeObserver.disconnect();
+      if (subscriptionCleanup) subscriptionCleanup();
+    });
+
     if (!hasSupabaseConfig()) return;
 
     let subscriptionCleanup: () => void;
-
-    onCleanup(() => {
-      if (subscriptionCleanup) subscriptionCleanup();
-    });
 
     (async () => {
       const {
@@ -47,7 +58,7 @@ export function Login() {
       fallback={
         <div class="flex min-w-0 items-center gap-2">
           <p class="hidden max-w-40 truncate text-sm sm:block">{session()?.user.email}</p>
-          <button class="btn btn-secondary btn-sm sm:btn-md" onClick={signOut}>
+          <button class="btn btn-ghost btn-sm sm:btn-md" onClick={signOut}>
             Logout
           </button>
         </div>
@@ -58,7 +69,7 @@ export function Login() {
         fallback={<span class="text-base-content/60 text-sm">Sign in unavailable</span>}
       >
         <button
-          class="btn btn-sm sm:btn-md"
+          class="btn btn-outline btn-sm sm:btn-md"
           onClick={() => {
             const modal = document.getElementById("login-modal");
             if (modal instanceof HTMLDialogElement) {
@@ -78,7 +89,8 @@ export function Login() {
               }}
               providers={["google"]}
               socialLayout={"horizontal"}
-              theme={"dark"}
+              theme="default"
+              dark={isDarkAuthTheme()}
               redirectTo={getRedirectUrl()}
             />
             <div class="modal-action">

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -12,7 +12,7 @@ export function Login() {
   onMount(() => {
     const html = document.documentElement;
     const updateAuthTheme = () => {
-      setIsDarkAuthTheme(html.getAttribute("data-theme") === "dim");
+      setIsDarkAuthTheme(html.dataset.theme === "dim");
     };
     updateAuthTheme();
 

--- a/src/components/players/PlayerForm.tsx
+++ b/src/components/players/PlayerForm.tsx
@@ -73,16 +73,20 @@ export default function PlayerForm() {
             </Switch>
           </div>
 
-          <div class="card-actions mt-4 justify-end">
+          <div class="card-actions mt-4 justify-end gap-2">
             <button
               type="button"
-              class="btn"
+              class="btn btn-ghost btn-sm sm:btn-md min-w-28"
               onClick={() => navigate("/players")}
               disabled={isSubmitting()}
             >
               Cancel
             </button>
-            <button type="submit" class="btn btn-primary" disabled={isSubmitting()}>
+            <button
+              type="submit"
+              class="btn btn-primary btn-sm sm:btn-md min-w-28"
+              disabled={isSubmitting()}
+            >
               <Show when={isSubmitting()} fallback={"Create Player"}>
                 <Spinner />
               </Show>

--- a/src/components/players/Players.tsx
+++ b/src/components/players/Players.tsx
@@ -75,7 +75,7 @@ function Players(props: RouteSectionProps) {
             {(resolvedData) => <DataTable columns={columns} data={resolvedData} />}
           </Show>
           <div class="mt-4 text-center">
-            <A class="btn btn-primary" href="/players/new">
+            <A class="btn btn-primary btn-sm sm:btn-md min-w-40" href="/players/new">
               Create New Player
             </A>
           </div>

--- a/src/components/players/Players.tsx
+++ b/src/components/players/Players.tsx
@@ -22,7 +22,7 @@ const columns: ColumnDef<Player>[] = [
       const player = info.row.original;
       return (
         <button
-          class="btn btn-error btn-sm"
+          class="btn btn-soft btn-error btn-sm"
           onClick={() => {
             setPlayerToDelete(player);
             setShowConfirm(true);

--- a/src/components/shared/ConfirmDeleteModal.tsx
+++ b/src/components/shared/ConfirmDeleteModal.tsx
@@ -37,8 +37,8 @@ const ConfirmDeleteModal = <T extends { id: number }>(props: ConfirmDeleteModalP
 
   return (
     <Show when={props.showConfirm}>
-      <div class="bg-opacity-50 fixed inset-0 z-50 flex items-center justify-center bg-black">
-        <div class="bg-base-300 w-80 rounded-lg p-6 shadow-lg">
+      <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div class="bg-base-100 border-base-300 w-80 rounded-lg border p-6 shadow-xl">
           <h2 class="text-base-content mb-4 text-lg font-semibold">Confirm Delete</h2>
           <p class="text-base-content mb-4">
             Are you sure you want to delete{" "}
@@ -47,10 +47,10 @@ const ConfirmDeleteModal = <T extends { id: number }>(props: ConfirmDeleteModalP
           {error() && <div class="alert alert-error mt-2">{error()}</div>}
 
           <div class="mt-2 flex justify-end gap-2">
-            <button class="btn btn-outline" onClick={handleCancel} disabled={isDeleting()}>
+            <button class="btn btn-ghost" onClick={handleCancel} disabled={isDeleting()}>
               Cancel
             </button>
-            <button class="btn btn-error" onClick={handleConfirm} disabled={isDeleting()}>
+            <button class="btn btn-soft btn-error" onClick={handleConfirm} disabled={isDeleting()}>
               {isDeleting() ? <Spinner /> : "Delete"}
             </button>
           </div>

--- a/src/components/shared/ConfirmDeleteModal.tsx
+++ b/src/components/shared/ConfirmDeleteModal.tsx
@@ -47,10 +47,18 @@ const ConfirmDeleteModal = <T extends { id: number }>(props: ConfirmDeleteModalP
           {error() && <div class="alert alert-error mt-2">{error()}</div>}
 
           <div class="mt-2 flex justify-end gap-2">
-            <button class="btn btn-ghost" onClick={handleCancel} disabled={isDeleting()}>
+            <button
+              class="btn btn-ghost btn-sm sm:btn-md min-w-24"
+              onClick={handleCancel}
+              disabled={isDeleting()}
+            >
               Cancel
             </button>
-            <button class="btn btn-soft btn-error" onClick={handleConfirm} disabled={isDeleting()}>
+            <button
+              class="btn btn-soft btn-error btn-sm sm:btn-md min-w-24"
+              onClick={handleConfirm}
+              disabled={isDeleting()}
+            >
               {isDeleting() ? <Spinner /> : "Delete"}
             </button>
           </div>

--- a/src/components/shared/table/Table.tsx
+++ b/src/components/shared/table/Table.tsx
@@ -8,7 +8,7 @@ import { cn } from "~/lib/utils";
 export const Table: ParentComponent<ComponentProps<"table">> = (rawProps) => {
   const [local, others] = splitProps(rawProps, ["class", "children"]);
   return (
-    <div class="rounded-box border-base-content/10 bg-base-300 overflow-x-auto border shadow-sm">
+    <div class="rounded-box border-base-300 bg-base-100 overflow-x-auto border shadow-sm">
       {/* DaisyUI "table" plus "table-compact" for a clean modern look. */}
       <table class={cn("table-compact table w-full", local.class)} {...others}>
         {local.children}
@@ -28,7 +28,7 @@ export const TableHeader: ParentComponent<JSX.HTMLAttributes<HTMLTableSectionEle
   return (
     /* Give the header a subtle background.
        "bg-base-200" is typically lighter, you can tweak to taste. */
-    <thead class={cn("bg-base-200", local.class)} {...others}>
+    <thead class={cn("bg-base-200/80", local.class)} {...others}>
       {local.children}
     </thead>
   );

--- a/src/components/teams/TeamForm.tsx
+++ b/src/components/teams/TeamForm.tsx
@@ -162,11 +162,11 @@ export default function TeamForm() {
                   () => players()?.find((p) => p.id === id)?.name ?? "Unknown"
                 );
                 return (
-                  <div class="badge badge-primary gap-2 p-3">
+                  <div class="badge badge-primary badge-soft gap-2 p-3">
                     {playerName()}
                     <button
                       type="button"
-                      class="btn btn-xs btn-circle btn-error ml-2"
+                      class="btn btn-xs btn-circle btn-ghost ml-2"
                       onClick={() => removePlayer(id)}
                     >
                       ✕

--- a/src/components/teams/TeamForm.tsx
+++ b/src/components/teams/TeamForm.tsx
@@ -190,16 +190,20 @@ export default function TeamForm() {
             </Switch>
           </div>
 
-          <div class="card-actions mt-4 justify-end">
+          <div class="card-actions mt-4 justify-end gap-2">
             <button
               type="button"
-              class="btn"
+              class="btn btn-ghost btn-sm sm:btn-md min-w-28"
               onClick={() => navigate("/teams")}
               disabled={isSubmitting()}
             >
               Cancel
             </button>
-            <button type="submit" class="btn btn-primary" disabled={isSubmitting()}>
+            <button
+              type="submit"
+              class="btn btn-primary btn-sm sm:btn-md min-w-28"
+              disabled={isSubmitting()}
+            >
               <Show when={isSubmitting()} fallback={isEditing() ? "Update Team" : "Create Team"}>
                 <Spinner />
               </Show>

--- a/src/components/teams/Teams.tsx
+++ b/src/components/teams/Teams.tsx
@@ -18,11 +18,11 @@ const columns: ColumnDef<TeamWithMembers>[] = [
       const team = info.row.original;
       return (
         <div class="flex gap-2">
-          <A class="btn btn-info btn-sm" href={`/teams/edit/${team.id}`}>
+          <A class="btn btn-outline btn-sm" href={`/teams/edit/${team.id}`}>
             Edit
           </A>
           <button
-            class="btn btn-error btn-sm"
+            class="btn btn-soft btn-error btn-sm"
             onClick={() => {
               setTeamToDelete(team);
               setShowConfirm(true);
@@ -47,9 +47,7 @@ const columns: ColumnDef<TeamWithMembers>[] = [
         <div class="flex flex-wrap gap-1">
           <For each={members}>
             {(member) => (
-              <span class="badge badge-sm badge-secondary">
-                {member.players?.name ?? "Unknown"}
-              </span>
+              <span class="badge badge-sm badge-outline">{member.players?.name ?? "Unknown"}</span>
             )}
           </For>
         </div>

--- a/src/components/teams/Teams.tsx
+++ b/src/components/teams/Teams.tsx
@@ -18,11 +18,11 @@ const columns: ColumnDef<TeamWithMembers>[] = [
       const team = info.row.original;
       return (
         <div class="flex gap-2">
-          <A class="btn btn-outline btn-sm" href={`/teams/edit/${team.id}`}>
+          <A class="btn btn-outline btn-sm min-w-20" href={`/teams/edit/${team.id}`}>
             Edit
           </A>
           <button
-            class="btn btn-soft btn-error btn-sm"
+            class="btn btn-soft btn-error btn-sm min-w-20"
             onClick={() => {
               setTeamToDelete(team);
               setShowConfirm(true);
@@ -69,7 +69,7 @@ export default function Teams(props: RouteSectionProps) {
       }
     >
       <TeamListContext.Provider value={{ refetchTeams: refetch }}>
-        <div class="p-2">
+        <div class="px-4 py-2">
           <div class="text-lg">Teams</div>
           <div class="mx-auto w-full">
             <Show
@@ -84,9 +84,11 @@ export default function Teams(props: RouteSectionProps) {
               {(resolvedData) => <DataTable columns={columns} data={resolvedData} />}
             </Show>
           </div>
-          <A class="btn btn-primary mx-auto mt-4 inline-block" href="/teams/new">
-            Create New Team
-          </A>
+          <div class="mt-4 text-center">
+            <A class="btn btn-primary btn-sm sm:btn-md min-w-40" href="/teams/new">
+              Create New Team
+            </A>
+          </div>
         </div>
 
         {props.children}

--- a/src/routes/MainLayout.tsx
+++ b/src/routes/MainLayout.tsx
@@ -7,8 +7,8 @@ import { SupabaseBanner } from "../components/SupabaseBanner.tsx";
 export const MainLayout: ParentComponent = (props) => {
   return (
     <div class="bg-base-200 text-base-content flex h-screen flex-col">
-      <div class="navbar border-base-300/80 bg-base-100/95 sticky top-0 z-30 min-h-16 gap-2 border-b px-3 shadow-sm backdrop-blur sm:px-4">
-        <div class="navbar-start min-w-0 gap-2">
+      <div class="navbar border-base-300/80 bg-base-100/95 sticky top-0 z-30 min-h-16 gap-1 border-b px-2 shadow-sm backdrop-blur sm:gap-2 sm:px-4">
+        <div class="navbar-start min-w-0 flex-1 gap-1 sm:gap-2">
           {/* Mobile hamburger */}
           <details class="dropdown shrink-0 lg:hidden">
             <summary class="btn btn-ghost btn-circle btn-sm list-none">
@@ -42,14 +42,11 @@ export const MainLayout: ParentComponent = (props) => {
           </details>
 
           <A
-            class="btn btn-ghost min-w-0 flex-1 justify-start truncate px-1 text-base sm:flex-none sm:px-2 sm:text-xl"
+            class="btn btn-ghost min-w-0 flex-1 justify-start truncate px-1 text-sm leading-tight font-semibold sm:flex-none sm:px-2 sm:text-xl"
             href={"/"}
           >
             Foosball Tracker
           </A>
-          <div class="shrink-0">
-            <ThemeSwitch />
-          </div>
         </div>
 
         {/* Desktop nav */}
@@ -68,7 +65,10 @@ export const MainLayout: ParentComponent = (props) => {
           </ul>
         </div>
 
-        <div class="navbar-end flex-none">
+        <div class="navbar-end ml-1 flex-none items-center gap-1 sm:ml-0 sm:gap-2">
+          <div class="shrink-0">
+            <ThemeSwitch />
+          </div>
           <Login />
         </div>
       </div>

--- a/src/routes/MainLayout.tsx
+++ b/src/routes/MainLayout.tsx
@@ -6,8 +6,8 @@ import { SupabaseBanner } from "../components/SupabaseBanner.tsx";
 
 export const MainLayout: ParentComponent = (props) => {
   return (
-    <div class={"flex h-screen flex-col"}>
-      <div class="navbar bg-base-100 min-h-16 gap-2 px-3 shadow-sm sm:px-4">
+    <div class="bg-base-200 text-base-content flex h-screen flex-col">
+      <div class="navbar border-base-300/80 bg-base-100/95 sticky top-0 z-30 min-h-16 gap-2 border-b px-3 shadow-sm backdrop-blur sm:px-4">
         <div class="navbar-start min-w-0 gap-2">
           {/* Mobile hamburger */}
           <details class="dropdown shrink-0 lg:hidden">
@@ -27,7 +27,7 @@ export const MainLayout: ParentComponent = (props) => {
                 />
               </svg>
             </summary>
-            <ul class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2 shadow">
+            <ul class="menu menu-sm dropdown-content bg-base-100 rounded-box border-base-300 z-[1] mt-3 w-52 border p-2 shadow-lg">
               <li>
                 <A href={"/players"} activeClass={"menu-active"}>
                   Players
@@ -73,7 +73,7 @@ export const MainLayout: ParentComponent = (props) => {
         </div>
       </div>
       <SupabaseBanner />
-      <div class={"flex-1 overflow-y-auto"}>{props.children}</div>
+      <div class="bg-base-200 flex-1 overflow-y-auto">{props.children}</div>
     </div>
   );
 };


### PR DESCRIPTION
Closes #11

## What changed
- switched the app to built-in DaisyUI themes `winter` and `dim` for a cleaner default palette
- established a clearer surface hierarchy between page background, nav, cards, tables, and modals
- softened secondary and destructive actions so buttons feel more consistent across the main screen and management views
- updated the auth modal theme handling to follow the active DaisyUI light/dark mode without runtime errors

## Why
The current main screen styling had weak separation between major surfaces on mobile and overly strong button emphasis in several places. This change brings the implementation closer to a coherent DaisyUI theme-driven design.

## Validation
- `npx pnpm@10 format:check`
- `npx pnpm@10 lint`
- `npx pnpm@10 build`
- verified desktop and mobile layouts with Playwright MCP
