### PR TITLE
feat: custom auth UI (#14)

### DIFF
--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["index.html"],
+  "insertBefore": "</body>",
+  "commentSyntax": "html",
+  "cspChecked": true
+}

--- a/.sonarlint/connectedMode.json
+++ b/.sonarlint/connectedMode.json
@@ -1,0 +1,5 @@
+{
+  "sonarCloudOrganization": "foosball-tracker",
+  "projectKey": "foosball-tracker_foosball-tracker",
+  "region": "EU"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # AGENTS.md
 
+## For Every Feature or Change
+
+**ALWAYS follow [`WORKFLOW.md`](./WORKFLOW.md)** from start to finish. It covers branch naming, commits, pre-commit checks, PR creation, Codex review, SonarQube checks, and merge. Do not skip steps or invent your own workflow.
+
+For UI changes, also follow [`docs/ai-ui-workflow.md`](./docs/ai-ui-workflow.md) exactly — including Playwright inspection at both viewports, proof capture, and proof publication.
+
 ## Stack
 
 - Solid.js SPA built with Vite
@@ -16,10 +22,8 @@
 - Format check: `npx pnpm@10 format:check`
 - Format: `npx pnpm@10 format`
 - Regenerate Supabase DB types: `npx pnpm@10 db-types`
-
-## Figma Design
-
-- Design file: https://www.figma.com/design/FNBuLTXbRtAAweZuF1nrxi/FoosBall-Tracker
+- UI proof capture: `npx pnpm@10 proof:capture -- --name <name> --route <route>`
+- UI proof publish: `npx pnpm@10 proof:publish`
 
 ## Repo Structure
 
@@ -40,70 +44,29 @@ Impeccable skills are installed at `.agents/skills/impeccable/` (for OpenCode/lo
 
 ## SolidJS Guidelines
 
-**USE SOLIDJS AS IMPLEMENTED IN THIS EXISTING PROJECT.**
-
-Before changing SolidJS code, consult the official Solid docs via:
-https://docs.solidjs.com/llms.txt
-
-Prefer official Solid patterns over React-like patterns.
-
-Important rules:
+**Use SolidJS as implemented in this existing project.** Consult https://docs.solidjs.com/llms.txt before changing SolidJS code.
 
 - Do not use React dependency arrays with `createEffect`/`createMemo`.
-- Access signals as functions, for example `count()`, not `count`.
+- Access signals as functions: `count()`, not `count`.
 - Use `onCleanup` for subscriptions, timers, event listeners, and WebSocket cleanup.
 - Prefer `createMemo` for derived reactive values.
 - Avoid destructuring props in a way that loses reactivity.
-- Follow the existing project style, folder structure, routing setup, and component patterns.
+- Follow existing project style, folder structure, routing setup, and component patterns.
 - Do not introduce a new UI library or state library unless the project already uses it.
-- If unsure, search the Solid docs first and cite the relevant doc section in your reasoning.
 
 ## Working Rules
 
 - Prefer small focused changes over broad refactors.
-- Keep Supabase-related changes typed and centralized in `src/service`.
-- Preserve the existing service/store split instead of moving data access into components.
-- For UI changes, follow [`docs/ai-ui-workflow.md`](./docs/ai-ui-workflow.md) exactly.
-- For UI changes, verify both desktop and mobile layouts.
-- For UI changes, publish PR proof screenshots with `npx pnpm@10 proof:capture` and `npx pnpm@10 proof:publish`, then verify the PR comment links render correctly before the PR is ready for review.
-- Run lint and build before opening a PR.
+- Keep Supabase changes typed and centralized in `src/service`.
+- Preserve the existing service/store split.
 - Avoid editing generated types manually unless the generation flow is broken.
-
-## Workflow
-
-For the full end-to-end guide (branch naming, PR creation, preview deploys, Codex review, SonarQube checks, merge), see [`WORKFLOW.md`](./WORKFLOW.md).
-
-## Environment Notes
-
-- The app expects Supabase environment variables in local development.
-- The `db-types` command depends on Supabase CLI access and project credentials.
-- If dependency upgrades require a newer Node runtime than the host default, use a transient newer Node for verification instead of changing project code to match the old runtime.
-- `SONARQUBE_TOKEN` is loaded from `~/.secrets/sonarqube_token` via the T3 systemd env file (`~/.config/t3-code/env`). Never hardcode it in the repo.
-
-## SonarQube MCP
-
-- Connected via the remote MCP server at `https://api.sonarcloud.io/mcp`.
-- Auth uses `Bearer {env:SONARQUBE_TOKEN}` through OpenCode env expansion.
-- Default project key: `foosball-tracker_foosball-tracker` (set via `SONARQUBE_PROJECT_KEY` header).
-- Organization: `foosball-tracker`.
-- Read-only mode is enabled (`SONARQUBE_READ_ONLY: true`).
-
-### Workflow after pushing / creating a PR
-
-1. Push your branch and open (or update) a PR on GitHub.
-2. Wait a few minutes for the SonarCloud CI analysis to complete.
-3. Use the SonarQube MCP tools to check the PR:
-   - `sonarqube_list_pull_requests` to find the PR key.
-   - `sonarqube_search_sonar_issues_in_projects` with `pullRequestId` to see new issues introduced by the PR.
-   - `sonarqube_get_project_quality_gate_status` with `pullRequest` to verify the quality gate passes.
-   - `sonarqube_search_security_hotspots` with `pullRequest` to review any security hotspots on the PR.
-4. Fix any issues that block the quality gate or are significant, then push again.
-5. Ignore issues in generated files (e.g. `src/types/database.ts`) unless the generation flow is broken.
+- **Ask the user before any Supabase schema change, migration, data mutation, or RLS policy change.**
+- Run lint and build before pushing.
+- Never hardcode secrets or tokens. `SONARQUBE_TOKEN` is loaded from `~/.secrets/sonarqube_token`.
 
 ## MCP & Skills
 
-- A Supabase MCP server is configured in `opencode.json` and a [Supabase skill](./.agents/skills/supabase/SKILL.md) is available locally.
-- You can use these to inspect, query, or check the project's Supabase instance directly (database, docs, debugging, development, functions, branching, storage).
-- **For any real changes or modifications to the Supabase project** (schema changes, migrations, data mutations, RLS policies, etc.), ask the user first before making the change.
-- A [DaisyUI skill](./.agents/skills/daisyui/SKILL.md) is available locally for component design guidance.
-- Playwright MCP is configured for both Codex and OpenCode through `.codex/playwright-mcp-launcher.mjs`. If you change MCP config, restart the session before retesting because local MCP servers do not reliably hot-reload.
+- **Supabase MCP**: inspect, query, or check the Supabase instance. A [skill](./.agents/skills/supabase/SKILL.md) is available.
+- **DaisyUI skill**: available at [.agents/skills/daisyui/SKILL.md](./.agents/skills/daisyui/SKILL.md).
+- **SonarQube MCP**: connected to `https://api.sonarcloud.io/mcp`. Project key: `foosball-tracker_foosball-tracker`. Usage steps are in WORKFLOW.md step 11.
+- **Playwright MCP**: configured via `.codex/playwright-mcp-launcher.mjs`. Restart session after MCP config changes.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,42 +1,33 @@
-# Product: Foosball Tracker
+# Product
 
 ## Register
 
-Product. Design serves the task.
+product
 
 ## Users
 
-Foosball players and enthusiasts tracking casual matches, scores, and team rosters. Typically in a social setting: a game room, office break area, or bar. Phone in hand, glancing between the table and the screen. Ambient lighting varies from bright to dim.
+Friends, private groups, and small tournament organizers who want a simple way to track foosball matches, scores, players, and teams. They are usually using the app during casual play or lightweight tournament sessions, often on a phone near the table, so the interface needs to be fast to scan and easy to operate in the moment.
 
-## Purpose
+## Product Purpose
 
-Track foosball matches in real time: start a game, record goals, see elapsed time, view goal history, manage players and teams. Secondary use: browse player and team records outside of active play.
+Foosball Tracker helps small groups keep score, manage players and teams, and maintain a clear overview of ongoing play without adding ceremony or complexity. Success looks like people being able to open the app, understand the current state immediately, and keep a match moving without the UI getting in the way.
 
 ## Brand Personality
 
-Functional, playful, direct. The app is a scoreboard with memory, not a social network. No gamification theatre, no achievement badges, no "level up" copy. The personality lives in the score display (large, bold numerals) and the team colour indicators, not in decorative elements.
+Clean, easy to handle, modern. The product should feel calm, straightforward, and dependable. It should support a strong overview of the game state, stay approachable for non-technical users, and feel polished on mobile as well as desktop.
 
-## Voice
+## Anti-references
 
-Clear, task-oriented. Button labels say what will happen: "Start Game", "Reset Game", "Create Player", "Delete". Error messages name the problem. No marketing language, no motivational copy.
-
-## Anti-References
-
-- Gamification cliches (XP bars, streak counters, achievement unlocks).
-- SaaS dashboard aesthetics applied to a game tracker.
-- Neon or arcade-themed "retro game" styling.
-- Purple gradients, glassmorphism, glass cards.
-- Heavy custom illustrations or mascot characters.
+Do not make this feel flashy, novelty-driven, over-animated, or visually loud. Avoid interfaces that prioritize visual tricks over usability, layouts that feel cluttered or cramped, and patterns that make the product feel like a public marketing site instead of a practical private tool.
 
 ## Design Principles
 
-1. **The table is the primary interface.** The app is a companion, not the main event. Get in, record the goal, get out.
-2. **Semantic colours only.** Every colour is a DaisyUI token that adapts to both themes. No hard-coded hex values in component code.
-3. **Consistency over surprise.** The same button shape, the same card structure, the same form vocabulary on every screen.
-4. **Both themes are first-class.** Every UI change must work in winter (light) and dim (dark).
+- Prioritize overview first: users should understand the current match state at a glance.
+- Keep interactions lightweight: common actions should take minimal thought and minimal taps.
+- Preserve familiar patterns: standard controls and consistent component behavior beat cleverness.
+- Design for real use at the table: mobile ergonomics and legibility matter as much as desktop polish.
+- Stay visually quiet: the interface should support the game, not compete with it.
 
-## Accessibility Needs
+## Accessibility & Inclusion
 
-- Touch targets must be large enough for one-handed use while standing.
-- Score numerals must be legible at a glance from arm's length.
-- Theme switch must respect `prefers-color-scheme` by default.
+Target solid baseline accessibility for everyday use, including strong text contrast, support for reduced motion, and reliable usability on small screens. Favor clear labels, touch-friendly controls, and layouts that remain readable and navigable during quick in-game interactions.

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -18,4 +18,37 @@ test.describe("anonymous routes", () => {
     await expect(page.getByRole("heading", { name: "Sign in" })).toBeVisible();
     await expect(page.locator("body")).toContainText(/manage teams, players, and matches/i);
   });
+
+  test("login page supports mode switching", async ({ page }) => {
+    await page.goto("/login");
+    const authPage = page.getByRole("main");
+
+    await expect(authPage.getByRole("heading", { name: "Sign in" })).toBeVisible();
+    await expect(authPage.getByRole("button", { name: "Continue with Google" })).toBeVisible();
+    await expect(authPage.getByLabel("Email address")).toBeVisible();
+    await expect(authPage.getByLabel("Password")).toBeVisible();
+
+    await authPage.getByRole("button", { name: "Create account" }).click();
+    await expect(authPage.getByRole("heading", { name: "Create account" })).toBeVisible();
+    await expect(authPage.getByLabel("Confirm password")).toBeVisible();
+
+    await authPage.getByRole("button", { name: /already have an account\? sign in/i }).click();
+    await expect(authPage.getByRole("heading", { name: "Sign in" })).toBeVisible();
+
+    await authPage.getByRole("button", { name: "Forgot password?" }).click();
+    await expect(authPage.getByRole("heading", { name: "Reset password" })).toBeVisible();
+    await expect(authPage.getByRole("button", { name: "Send reset link" })).toBeVisible();
+    await expect(authPage.getByLabel("Password")).toHaveCount(0);
+  });
+
+  test("recovery link opens reset password mode", async ({ page }) => {
+    await page.goto("/login#type=recovery&access_token=test&refresh_token=test");
+    const authPage = page.getByRole("main");
+
+    await expect(authPage.getByRole("heading", { name: "Choose a new password" })).toBeVisible();
+    await expect(authPage.getByLabel("New password")).toBeVisible();
+    await expect(authPage.getByLabel("Confirm password")).toBeVisible();
+    await expect(authPage.getByRole("button", { name: "Save new password" })).toBeVisible();
+    await expect(authPage.getByLabel("Email address")).toHaveCount(0);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
   "dependencies": {
     "@solid-primitives/scheduled": "^1.5.3",
     "@solidjs/router": "^0.16.1",
-    "@supabase/auth-ui-shared": "^0.1.8",
-    "@supabase/auth-ui-solid": "^0.3.8",
     "@supabase/supabase-js": "^2.105.4",
     "@tanstack/solid-table": "^8.21.3",
     "lucide-solid": "^1.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,6 @@ importers:
       '@solidjs/router':
         specifier: ^0.16.1
         version: 0.16.1(solid-js@1.9.13)
-      '@supabase/auth-ui-shared':
-        specifier: ^0.1.8
-        version: 0.1.8(@supabase/supabase-js@2.105.4)
-      '@supabase/auth-ui-solid':
-        specifier: ^0.3.8
-        version: 0.3.8(@supabase/supabase-js@2.105.4)
       '@supabase/supabase-js':
         specifier: ^2.105.4
         version: 2.105.4
@@ -611,20 +605,9 @@ packages:
     peerDependencies:
       solid-js: ^1.8.6
 
-  '@stitches/core@1.2.8':
-    resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
-
   '@supabase/auth-js@2.105.4':
     resolution: {integrity: sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==}
     engines: {node: '>=20.0.0'}
-
-  '@supabase/auth-ui-shared@0.1.8':
-    resolution: {integrity: sha512-ouQ0DjKcEFg+0gZigFIEgu01V3e6riGZPzgVD0MJsCBNsMsiDT74+GgCEIElMUpTGkwSja3xLwdFRFgMNFKcjg==}
-    peerDependencies:
-      '@supabase/supabase-js': ^2.21.0
-
-  '@supabase/auth-ui-solid@0.3.8':
-    resolution: {integrity: sha512-W9BPG1IbIG5XnLlGnJvhC7yr7cEnqe7jIT+h1JbFdJeT4BMl4diZp23GfCNcLOfpDbHvNxPJ3Ost8actMpJC4Q==}
 
   '@supabase/functions-js@2.105.4':
     resolution: {integrity: sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==}
@@ -1552,9 +1535,6 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
-
-  just-merge@3.2.0:
-    resolution: {integrity: sha512-cNh5FWt44hx4SpQS1xZU8Tzr/fQA69pqCdjbwxmaYYIOuRfA8EIg+dn1bGmIW03ZUtR2vkMOCjWKc+jIbpauSw==}
 
   kebab-case@1.0.2:
     resolution: {integrity: sha512-7n6wXq4gNgBELfDCpzKc+mRrZFs7D+wgfF5WRFLNAr4DA/qtr9Js8uOAVAfHhuLMfAcQ0pRKqbpjx+TcJVdE1Q==}
@@ -2688,24 +2668,9 @@ snapshots:
     dependencies:
       solid-js: 1.9.13
 
-  '@stitches/core@1.2.8': {}
-
   '@supabase/auth-js@2.105.4':
     dependencies:
       tslib: 2.8.1
-
-  '@supabase/auth-ui-shared@0.1.8(@supabase/supabase-js@2.105.4)':
-    dependencies:
-      '@supabase/supabase-js': 2.105.4
-
-  '@supabase/auth-ui-solid@0.3.8(@supabase/supabase-js@2.105.4)':
-    dependencies:
-      '@stitches/core': 1.2.8
-      '@supabase/auth-ui-shared': 0.1.8(@supabase/supabase-js@2.105.4)
-      just-merge: 3.2.0
-      solid-js: 1.9.13
-    transitivePeerDependencies:
-      - '@supabase/supabase-js'
 
   '@supabase/functions-js@2.105.4':
     dependencies:
@@ -3669,8 +3634,6 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
-
-  just-merge@3.2.0: {}
 
   kebab-case@1.0.2: {}
 

--- a/src/components/auth/AuthDialog.tsx
+++ b/src/components/auth/AuthDialog.tsx
@@ -20,9 +20,8 @@ export function AuthDialog(props: Readonly<AuthDialogProps>) {
         {props.buttonLabel ?? "Sign in"}
       </button>
       <dialog id="login-modal" class="modal">
-        <div class="modal-box">
-          <h3 class="text-lg font-bold">Sign in</h3>
-          <AuthForm />
+        <div class="modal-box max-w-md p-6 sm:p-8">
+          <AuthForm surface="plain" />
           <div class="modal-action">
             <form method="dialog">
               <button class="btn btn-ghost btn-sm sm:btn-md">Close</button>

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -1,39 +1,475 @@
-import { Auth } from "@supabase/auth-ui-solid";
-import { ThemeSupa } from "@supabase/auth-ui-shared";
-import { createSignal, onCleanup, onMount } from "solid-js";
-import { getRedirectUrl } from "~/components/auth/authHelper.ts";
+import { A, useNavigate } from "@solidjs/router";
+import { createEffect, createMemo, createSignal, Match, onCleanup, Show, Switch } from "solid-js";
+import { getAuthRouteUrl, getRedirectUrl } from "~/components/auth/authHelper.ts";
+import { useAuthSession } from "~/hooks/useAuthSession.ts";
 import { supabase } from "~/service/supabaseService.ts";
 
-export function AuthForm() {
-  const [isDarkAuthTheme, setIsDarkAuthTheme] = createSignal(false);
+type AuthMode = "signin" | "signup" | "forgot" | "reset";
+type AuthSurface = "card" | "plain";
 
-  onMount(() => {
-    const html = document.documentElement;
-    const updateAuthTheme = () => {
-      setIsDarkAuthTheme(html.dataset.theme === "dim");
-    };
+interface AuthFormProps {
+  idPrefix?: string;
+  showBackLink?: boolean;
+  surface?: AuthSurface;
+}
 
-    updateAuthTheme();
+const modeCopy: Record<
+  AuthMode,
+  {
+    title: string;
+    description: string;
+    submitLabel: string;
+  }
+> = {
+  signin: {
+    title: "Sign in",
+    description: "Use your email or Google account to manage teams, players, and matches.",
+    submitLabel: "Sign in",
+  },
+  signup: {
+    title: "Create account",
+    description: "Set up an account so you can keep scores, players, and teams in sync.",
+    submitLabel: "Create account",
+  },
+  forgot: {
+    title: "Reset password",
+    description: "Enter your email address and we will send you a link to choose a new password.",
+    submitLabel: "Send reset link",
+  },
+  reset: {
+    title: "Choose a new password",
+    description: "Set a new password for your account, then continue back to the app.",
+    submitLabel: "Save new password",
+  },
+};
 
-    const themeObserver = new MutationObserver(updateAuthTheme);
-    themeObserver.observe(html, { attributes: true, attributeFilter: ["data-theme"] });
+function validateEmail(email: string) {
+  return /.+@.+\..+/.test(email);
+}
 
-    onCleanup(() => {
-      themeObserver.disconnect();
-    });
+function mapAuthError(error: unknown, mode: AuthMode) {
+  if (!(error instanceof Error)) {
+    return "Something went wrong. Please try again.";
+  }
+
+  const message = error.message.toLowerCase();
+
+  if (
+    message.includes("invalid login credentials") ||
+    message.includes("invalid email or password")
+  ) {
+    return "Email or password is incorrect.";
+  }
+
+  if (message.includes("email not confirmed")) {
+    return "Check your email and confirm your account before signing in.";
+  }
+
+  if (message.includes("user already registered") || message.includes("already been registered")) {
+    return "An account with this email already exists. Try signing in instead.";
+  }
+
+  if (message.includes("password should be at least")) {
+    return "Use a password with at least 6 characters.";
+  }
+
+  if (message.includes("same password")) {
+    return "Choose a new password that is different from your current one.";
+  }
+
+  if (
+    message.includes("expired") ||
+    message.includes("invalid refresh token") ||
+    message.includes("auth session missing")
+  ) {
+    return mode === "reset"
+      ? "This recovery link has expired. Request a new password reset email."
+      : "This sign-in link is no longer valid. Please try again.";
+  }
+
+  if (message.includes("network")) {
+    return "The app could not reach the sign-in service. Please try again.";
+  }
+
+  if (mode === "forgot") {
+    return "We could not send the reset email right now. Please try again.";
+  }
+
+  if (mode === "signup") {
+    return "We could not create your account right now. Please try again.";
+  }
+
+  if (mode === "reset") {
+    return "We could not save your new password right now. Please try again.";
+  }
+
+  return "We could not sign you in right now. Please try again.";
+}
+
+export function AuthForm(props: Readonly<AuthFormProps>) {
+  const navigate = useNavigate();
+  const { clearRecoveryMode, recoveryMode } = useAuthSession();
+  const fieldId = (name: string) => (props.idPrefix ? `${props.idPrefix}-${name}` : name);
+  const [mode, setMode] = createSignal<AuthMode>(recoveryMode() ? "reset" : "signin");
+  const [email, setEmail] = createSignal("");
+  const [password, setPassword] = createSignal("");
+  const [confirmPassword, setConfirmPassword] = createSignal("");
+  const [activeAction, setActiveAction] = createSignal<"email" | "google" | null>(null);
+  const [isSubmitting, setIsSubmitting] = createSignal(false);
+  const [errorMessage, setErrorMessage] = createSignal<string | null>(null);
+  const [successMessage, setSuccessMessage] = createSignal<string | null>(null);
+  let redirectTimer: ReturnType<typeof setTimeout> | undefined;
+
+  onCleanup(() => {
+    if (redirectTimer) {
+      clearTimeout(redirectTimer);
+    }
   });
 
+  createEffect(() => {
+    if (recoveryMode()) {
+      setMode("reset");
+      setErrorMessage(null);
+      setSuccessMessage(null);
+      return;
+    }
+
+    if (mode() === "reset") {
+      setMode("signin");
+      setErrorMessage(null);
+      setSuccessMessage(null);
+    }
+  });
+
+  const currentCopy = createMemo(() => modeCopy[mode()]);
+  const isPlainSurface = createMemo(() => props.surface === "plain");
+  const showGoogleButton = createMemo(() => mode() === "signin" || mode() === "signup");
+  const showPasswordField = createMemo(
+    () => mode() === "signin" || mode() === "signup" || mode() === "reset"
+  );
+  const showConfirmPasswordField = createMemo(() => mode() === "signup" || mode() === "reset");
+
+  const switchMode = (nextMode: AuthMode) => {
+    if (mode() === nextMode) return;
+    setMode(nextMode);
+    setPassword("");
+    setConfirmPassword("");
+    setErrorMessage(null);
+    setSuccessMessage(null);
+
+    if (nextMode !== "reset") {
+      clearRecoveryMode();
+    }
+  };
+
+  const validateForm = () => {
+    const trimmedEmail = email().trim();
+
+    if (mode() !== "reset") {
+      if (!trimmedEmail) {
+        return "Enter your email address.";
+      }
+
+      if (!validateEmail(trimmedEmail)) {
+        return "Enter a valid email address.";
+      }
+    }
+
+    if (showPasswordField() && !password()) {
+      return mode() === "reset" ? "Enter a new password." : "Enter your password.";
+    }
+
+    if ((mode() === "signup" || mode() === "reset") && password().length < 6) {
+      return "Use a password with at least 6 characters.";
+    }
+
+    if (showConfirmPasswordField() && password() !== confirmPassword()) {
+      return "Passwords do not match.";
+    }
+
+    return null;
+  };
+
+  const handleEmailSubmit = async () => {
+    const validationError = validateForm();
+    if (validationError) {
+      setErrorMessage(validationError);
+      return;
+    }
+
+    setActiveAction("email");
+    setIsSubmitting(true);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+
+    try {
+      if (!supabase) {
+        throw new Error("Supabase is not configured");
+      }
+
+      if (mode() === "signin") {
+        const { error } = await supabase.auth.signInWithPassword({
+          email: email().trim(),
+          password: password(),
+        });
+        if (error) throw error;
+      }
+
+      if (mode() === "signup") {
+        const { data, error } = await supabase.auth.signUp({
+          email: email().trim(),
+          password: password(),
+          options: {
+            emailRedirectTo: getRedirectUrl(),
+          },
+        });
+        if (error) throw error;
+
+        setPassword("");
+        setConfirmPassword("");
+
+        if (!data.session) {
+          setSuccessMessage("Check your email to confirm your account, then sign in.");
+          setMode("signin");
+        }
+      }
+
+      if (mode() === "forgot") {
+        const { error } = await supabase.auth.resetPasswordForEmail(email().trim(), {
+          redirectTo: getAuthRouteUrl("/login"),
+        });
+        if (error) throw error;
+
+        setSuccessMessage("If that email is registered, a reset link is on its way.");
+      }
+
+      if (mode() === "reset") {
+        const { error } = await supabase.auth.updateUser({ password: password() });
+        if (error) throw error;
+
+        setPassword("");
+        setConfirmPassword("");
+        setSuccessMessage("Password updated. Redirecting you back to the app.");
+        redirectTimer = setTimeout(() => {
+          clearRecoveryMode();
+          navigate("/", { replace: true });
+        }, 900);
+      }
+    } catch (error) {
+      setErrorMessage(mapAuthError(error, mode()));
+    } finally {
+      setIsSubmitting(false);
+      setActiveAction(null);
+    }
+  };
+
+  const handleGoogleSignIn = async () => {
+    setActiveAction("google");
+    setIsSubmitting(true);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+
+    try {
+      if (!supabase) {
+        throw new Error("Supabase is not configured");
+      }
+
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: {
+          redirectTo: getRedirectUrl(),
+        },
+      });
+
+      if (error) {
+        throw error;
+      }
+    } catch (error) {
+      setErrorMessage("Google sign-in is unavailable right now. Please try again.");
+      console.error(error);
+      setIsSubmitting(false);
+      setActiveAction(null);
+    }
+  };
+
+  const content = (
+    <>
+      <div class="space-y-2">
+        <h1 class="text-2xl font-black tracking-tight">{currentCopy().title}</h1>
+        <p class="text-base-content/80 text-sm leading-6">{currentCopy().description}</p>
+      </div>
+
+      <Switch>
+        <Match when={errorMessage()}>
+          <div class="alert alert-error text-sm">
+            <span>{errorMessage()}</span>
+          </div>
+        </Match>
+        <Match when={successMessage()}>
+          <div class="alert alert-success text-sm">
+            <span>{successMessage()}</span>
+          </div>
+        </Match>
+      </Switch>
+
+      <Show when={showGoogleButton()}>
+        <button
+          type="button"
+          class="btn btn-outline w-full"
+          disabled={isSubmitting()}
+          onClick={() => void handleGoogleSignIn()}
+        >
+          <Show when={activeAction() === "google"} fallback={"Continue with Google"}>
+            <span class="loading loading-spinner loading-sm" aria-hidden="true" />
+          </Show>
+        </button>
+
+        <div class="divider my-1 text-xs">or</div>
+      </Show>
+
+      <form
+        class="space-y-4"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void handleEmailSubmit();
+        }}
+      >
+        <Show when={mode() !== "reset"}>
+          <fieldset class="fieldset gap-1">
+            <label class="fieldset-legend" for={fieldId("email")}>
+              Email address
+            </label>
+            <input
+              id={fieldId("email")}
+              type="email"
+              class="input input-bordered w-full"
+              value={email()}
+              onInput={(event) => setEmail(event.currentTarget.value)}
+              placeholder="name@example.com"
+              autocomplete="email"
+              autocapitalize="none"
+              spellcheck={false}
+              disabled={isSubmitting()}
+            />
+          </fieldset>
+        </Show>
+
+        <Show when={showPasswordField()}>
+          <fieldset class="fieldset gap-1">
+            <label class="fieldset-legend" for={fieldId("password")}>
+              {mode() === "reset" ? "New password" : "Password"}
+            </label>
+            <input
+              id={fieldId("password")}
+              type="password"
+              class="input input-bordered w-full"
+              value={password()}
+              onInput={(event) => setPassword(event.currentTarget.value)}
+              placeholder={mode() === "reset" ? "Choose a new password" : "Enter your password"}
+              autocomplete={mode() === "signin" ? "current-password" : "new-password"}
+              disabled={isSubmitting()}
+            />
+          </fieldset>
+        </Show>
+
+        <Show when={showConfirmPasswordField()}>
+          <fieldset class="fieldset gap-1">
+            <label class="fieldset-legend" for={fieldId("confirm-password")}>
+              Confirm password
+            </label>
+            <input
+              id={fieldId("confirm-password")}
+              type="password"
+              class="input input-bordered w-full"
+              value={confirmPassword()}
+              onInput={(event) => setConfirmPassword(event.currentTarget.value)}
+              placeholder="Repeat your password"
+              autocomplete="new-password"
+              disabled={isSubmitting()}
+            />
+          </fieldset>
+        </Show>
+
+        <div class="space-y-3 pt-2">
+          <button type="submit" class="btn btn-primary w-full" disabled={isSubmitting()}>
+            <Show when={activeAction() === "email"} fallback={currentCopy().submitLabel}>
+              <span class="loading loading-spinner loading-sm" aria-hidden="true" />
+            </Show>
+          </button>
+
+          <div class="flex flex-wrap items-center justify-between gap-2 text-sm">
+            <Show when={mode() === "signin"}>
+              <>
+                <button
+                  type="button"
+                  class="link link-hover text-base-content/80 font-medium"
+                  onClick={() => switchMode("forgot")}
+                >
+                  Forgot password?
+                </button>
+                <button
+                  type="button"
+                  class="link link-hover text-base-content font-medium"
+                  onClick={() => switchMode("signup")}
+                >
+                  Create account
+                </button>
+              </>
+            </Show>
+
+            <Show when={mode() === "signup"}>
+              <button
+                type="button"
+                class="link link-hover text-base-content font-medium"
+                onClick={() => switchMode("signin")}
+              >
+                Already have an account? Sign in
+              </button>
+            </Show>
+
+            <Show when={mode() === "forgot"}>
+              <button
+                type="button"
+                class="link link-hover text-base-content font-medium"
+                onClick={() => switchMode("signin")}
+              >
+                Back to sign in
+              </button>
+            </Show>
+
+            <Show when={mode() === "reset"}>
+              <button
+                type="button"
+                class="link link-hover text-base-content font-medium"
+                onClick={() => switchMode("forgot")}
+              >
+                Request a new reset link
+              </button>
+            </Show>
+          </div>
+        </div>
+      </form>
+
+      <Show when={props.showBackLink}>
+        <div class="card-actions justify-start pt-2">
+          <A class="btn btn-ghost btn-sm" href="/">
+            Back to start
+          </A>
+        </div>
+      </Show>
+    </>
+  );
+
   return (
-    <Auth
-      supabaseClient={supabase!}
-      appearance={{
-        theme: ThemeSupa,
-      }}
-      providers={["google"]}
-      socialLayout="horizontal"
-      theme="default"
-      dark={isDarkAuthTheme()}
-      redirectTo={getRedirectUrl()}
-    />
+    <Show
+      when={isPlainSurface()}
+      fallback={
+        <div class="card border-base-300 bg-base-100 shadow-sm">
+          <div class="card-body gap-5 p-6 sm:p-8">{content}</div>
+        </div>
+      }
+    >
+      <div class="flex flex-col gap-5">{content}</div>
+    </Show>
   );
 }

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -44,7 +44,16 @@ const modeCopy: Record<
 };
 
 function validateEmail(email: string) {
-  return /.+@.+\..+/.test(email);
+  const trimmedEmail = email.trim();
+  const atIndex = trimmedEmail.indexOf("@");
+  const dotIndex = trimmedEmail.lastIndexOf(".");
+
+  return (
+    atIndex > 0 &&
+    dotIndex > atIndex + 1 &&
+    dotIndex < trimmedEmail.length - 1 &&
+    !trimmedEmail.includes(" ")
+  );
 }
 
 function mapAuthError(error: unknown, mode: AuthMode) {
@@ -190,6 +199,72 @@ export function AuthForm(props: Readonly<AuthFormProps>) {
     return null;
   };
 
+  const handleSignIn = async () => {
+    const { error } = await supabase!.auth.signInWithPassword({
+      email: email().trim(),
+      password: password(),
+    });
+    if (error) throw error;
+  };
+
+  const handleSignUp = async () => {
+    const { data, error } = await supabase!.auth.signUp({
+      email: email().trim(),
+      password: password(),
+      options: {
+        emailRedirectTo: getRedirectUrl(),
+      },
+    });
+    if (error) throw error;
+
+    setPassword("");
+    setConfirmPassword("");
+
+    if (!data.session) {
+      setSuccessMessage("Check your email to confirm your account, then sign in.");
+      setMode("signin");
+    }
+  };
+
+  const handleForgotPassword = async () => {
+    const { error } = await supabase!.auth.resetPasswordForEmail(email().trim(), {
+      redirectTo: getAuthRouteUrl("/login"),
+    });
+    if (error) throw error;
+
+    setSuccessMessage("If that email is registered, a reset link is on its way.");
+  };
+
+  const handlePasswordReset = async () => {
+    const { error } = await supabase!.auth.updateUser({ password: password() });
+    if (error) throw error;
+
+    setPassword("");
+    setConfirmPassword("");
+    setSuccessMessage("Password updated. Redirecting you back to the app.");
+    redirectTimer = setTimeout(() => {
+      clearRecoveryMode();
+      navigate("/", { replace: true });
+    }, 900);
+  };
+
+  const runEmailAction = async () => {
+    switch (mode()) {
+      case "signin":
+        await handleSignIn();
+        return;
+      case "signup":
+        await handleSignUp();
+        return;
+      case "forgot":
+        await handleForgotPassword();
+        return;
+      case "reset":
+        await handlePasswordReset();
+        return;
+    }
+  };
+
   const handleEmailSubmit = async () => {
     const validationError = validateForm();
     if (validationError) {
@@ -207,54 +282,7 @@ export function AuthForm(props: Readonly<AuthFormProps>) {
         throw new Error("Supabase is not configured");
       }
 
-      if (mode() === "signin") {
-        const { error } = await supabase.auth.signInWithPassword({
-          email: email().trim(),
-          password: password(),
-        });
-        if (error) throw error;
-      }
-
-      if (mode() === "signup") {
-        const { data, error } = await supabase.auth.signUp({
-          email: email().trim(),
-          password: password(),
-          options: {
-            emailRedirectTo: getRedirectUrl(),
-          },
-        });
-        if (error) throw error;
-
-        setPassword("");
-        setConfirmPassword("");
-
-        if (!data.session) {
-          setSuccessMessage("Check your email to confirm your account, then sign in.");
-          setMode("signin");
-        }
-      }
-
-      if (mode() === "forgot") {
-        const { error } = await supabase.auth.resetPasswordForEmail(email().trim(), {
-          redirectTo: getAuthRouteUrl("/login"),
-        });
-        if (error) throw error;
-
-        setSuccessMessage("If that email is registered, a reset link is on its way.");
-      }
-
-      if (mode() === "reset") {
-        const { error } = await supabase.auth.updateUser({ password: password() });
-        if (error) throw error;
-
-        setPassword("");
-        setConfirmPassword("");
-        setSuccessMessage("Password updated. Redirecting you back to the app.");
-        redirectTimer = setTimeout(() => {
-          clearRecoveryMode();
-          navigate("/", { replace: true });
-        }, 900);
-      }
+      await runEmailAction();
     } catch (error) {
       setErrorMessage(mapAuthError(error, mode()));
     } finally {
@@ -335,8 +363,8 @@ export function AuthForm(props: Readonly<AuthFormProps>) {
         }}
       >
         <Show when={mode() !== "reset"}>
-          <fieldset class="fieldset gap-1">
-            <label class="fieldset-legend" for={fieldId("email")}>
+          <div class="flex flex-col gap-1.5">
+            <label class="text-sm font-semibold" for={fieldId("email")}>
               Email address
             </label>
             <input
@@ -351,12 +379,12 @@ export function AuthForm(props: Readonly<AuthFormProps>) {
               spellcheck={false}
               disabled={isSubmitting()}
             />
-          </fieldset>
+          </div>
         </Show>
 
         <Show when={showPasswordField()}>
-          <fieldset class="fieldset gap-1">
-            <label class="fieldset-legend" for={fieldId("password")}>
+          <div class="flex flex-col gap-1.5">
+            <label class="text-sm font-semibold" for={fieldId("password")}>
               {mode() === "reset" ? "New password" : "Password"}
             </label>
             <input
@@ -369,12 +397,12 @@ export function AuthForm(props: Readonly<AuthFormProps>) {
               autocomplete={mode() === "signin" ? "current-password" : "new-password"}
               disabled={isSubmitting()}
             />
-          </fieldset>
+          </div>
         </Show>
 
         <Show when={showConfirmPasswordField()}>
-          <fieldset class="fieldset gap-1">
-            <label class="fieldset-legend" for={fieldId("confirm-password")}>
+          <div class="flex flex-col gap-1.5">
+            <label class="text-sm font-semibold" for={fieldId("confirm-password")}>
               Confirm password
             </label>
             <input
@@ -387,7 +415,7 @@ export function AuthForm(props: Readonly<AuthFormProps>) {
               autocomplete="new-password"
               disabled={isSubmitting()}
             />
-          </fieldset>
+          </div>
         </Show>
 
         <div class="space-y-3 pt-2">

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -364,57 +364,57 @@ export function AuthForm(props: Readonly<AuthFormProps>) {
       >
         <Show when={mode() !== "reset"}>
           <div class="flex flex-col gap-1.5">
-            <label class="text-sm font-semibold" for={fieldId("email")}>
-              Email address
+            <label class="flex flex-col gap-1.5 text-sm font-semibold">
+              <span>Email address</span>
+              <input
+                id={fieldId("email")}
+                type="email"
+                class="input input-bordered w-full"
+                value={email()}
+                onInput={(event) => setEmail(event.currentTarget.value)}
+                placeholder="name@example.com"
+                autocomplete="email"
+                autocapitalize="none"
+                spellcheck={false}
+                disabled={isSubmitting()}
+              />
             </label>
-            <input
-              id={fieldId("email")}
-              type="email"
-              class="input input-bordered w-full"
-              value={email()}
-              onInput={(event) => setEmail(event.currentTarget.value)}
-              placeholder="name@example.com"
-              autocomplete="email"
-              autocapitalize="none"
-              spellcheck={false}
-              disabled={isSubmitting()}
-            />
           </div>
         </Show>
 
         <Show when={showPasswordField()}>
           <div class="flex flex-col gap-1.5">
-            <label class="text-sm font-semibold" for={fieldId("password")}>
-              {mode() === "reset" ? "New password" : "Password"}
+            <label class="flex flex-col gap-1.5 text-sm font-semibold">
+              <span>{mode() === "reset" ? "New password" : "Password"}</span>
+              <input
+                id={fieldId("password")}
+                type="password"
+                class="input input-bordered w-full"
+                value={password()}
+                onInput={(event) => setPassword(event.currentTarget.value)}
+                placeholder={mode() === "reset" ? "Choose a new password" : "Enter your password"}
+                autocomplete={mode() === "signin" ? "current-password" : "new-password"}
+                disabled={isSubmitting()}
+              />
             </label>
-            <input
-              id={fieldId("password")}
-              type="password"
-              class="input input-bordered w-full"
-              value={password()}
-              onInput={(event) => setPassword(event.currentTarget.value)}
-              placeholder={mode() === "reset" ? "Choose a new password" : "Enter your password"}
-              autocomplete={mode() === "signin" ? "current-password" : "new-password"}
-              disabled={isSubmitting()}
-            />
           </div>
         </Show>
 
         <Show when={showConfirmPasswordField()}>
           <div class="flex flex-col gap-1.5">
-            <label class="text-sm font-semibold" for={fieldId("confirm-password")}>
-              Confirm password
+            <label class="flex flex-col gap-1.5 text-sm font-semibold">
+              <span>Confirm password</span>
+              <input
+                id={fieldId("confirm-password")}
+                type="password"
+                class="input input-bordered w-full"
+                value={confirmPassword()}
+                onInput={(event) => setConfirmPassword(event.currentTarget.value)}
+                placeholder="Repeat your password"
+                autocomplete="new-password"
+                disabled={isSubmitting()}
+              />
             </label>
-            <input
-              id={fieldId("confirm-password")}
-              type="password"
-              class="input input-bordered w-full"
-              value={confirmPassword()}
-              onInput={(event) => setConfirmPassword(event.currentTarget.value)}
-              placeholder="Repeat your password"
-              autocomplete="new-password"
-              disabled={isSubmitting()}
-            />
           </div>
         </Show>
 

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -8,11 +8,14 @@ import {
   type Accessor,
   type JSX,
 } from "solid-js";
+import { clearAuthRedirectState, isRecoveryRedirect } from "~/components/auth/authHelper.ts";
 import { hasSupabaseConfig, supabase } from "~/service/supabaseService";
 
 interface AuthContextValue {
   loading: Accessor<boolean>;
+  recoveryMode: Accessor<boolean>;
   session: Accessor<Session | null>;
+  clearRecoveryMode: () => void;
   signOut: () => Promise<void>;
 }
 
@@ -21,6 +24,7 @@ const AuthContext = createContext<AuthContextValue>();
 export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
   const [session, setSession] = createSignal<Session | null>(null);
   const [loading, setLoading] = createSignal(hasSupabaseConfig());
+  const [recoveryMode, setRecoveryMode] = createSignal(false);
 
   onMount(() => {
     let disposed = false;
@@ -39,13 +43,28 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
       if (disposed) return;
 
       setSession(currentSession);
+      setRecoveryMode(isRecoveryRedirect());
       setLoading(false);
 
       const {
         data: { subscription },
-      } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      } = supabase.auth.onAuthStateChange((event, nextSession) => {
         setSession(nextSession);
         setLoading(false);
+
+        if (event === "PASSWORD_RECOVERY") {
+          setRecoveryMode(true);
+          return;
+        }
+
+        if (event === "INITIAL_SESSION") {
+          setRecoveryMode(isRecoveryRedirect());
+          return;
+        }
+
+        if (event === "SIGNED_OUT") {
+          setRecoveryMode(false);
+        }
       });
 
       unsubscribe = () => subscription.unsubscribe();
@@ -57,6 +76,11 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
     });
   });
 
+  const clearRecoveryMode = () => {
+    setRecoveryMode(false);
+    clearAuthRedirectState();
+  };
+
   const signOut = async () => {
     if (!supabase) return;
     const { error } = await supabase.auth.signOut();
@@ -66,7 +90,7 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
   };
 
   return (
-    <AuthContext.Provider value={{ loading, session, signOut }}>
+    <AuthContext.Provider value={{ loading, recoveryMode, session, clearRecoveryMode, signOut }}>
       {props.children}
     </AuthContext.Provider>
   );

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -17,35 +17,35 @@ export default function LoginPage() {
 
   return (
     <main class="mx-auto flex min-h-full w-full max-w-lg flex-col justify-center px-4 py-8 sm:px-6">
-      <div class="card border-base-300 bg-base-100 shadow-sm">
-        <div class="card-body gap-5 p-6 sm:p-8">
-          <div>
-            <h1 class="text-2xl font-black tracking-tight">Sign in</h1>
-            <p class="text-base-content/70 mt-2 text-sm">
-              Sign in to manage teams, players, and matches.
-            </p>
-          </div>
-
-          <Show when={!loading()} fallback={<Spinner />}>
-            <Show
-              when={hasSupabaseConfig()}
-              fallback={
-                <div class="alert alert-warning">
-                  <span>Supabase is not configured. Sign in is unavailable.</span>
+      <Show when={!loading()} fallback={<Spinner />}>
+        <Show
+          when={hasSupabaseConfig()}
+          fallback={
+            <div class="card border-base-300 bg-base-100 shadow-sm">
+              <div class="card-body gap-5 p-6 sm:p-8">
+                <div class="space-y-2">
+                  <h1 class="text-2xl font-black tracking-tight">Sign in unavailable</h1>
+                  <p class="text-base-content/80 text-sm">
+                    Supabase is not configured, so authentication cannot be used right now.
+                  </p>
                 </div>
-              }
-            >
-              <AuthForm />
-            </Show>
-          </Show>
 
-          <div class="card-actions justify-start">
-            <A class="btn btn-ghost btn-sm" href="/">
-              Back to start
-            </A>
-          </div>
-        </div>
-      </div>
+                <div class="alert alert-warning text-sm">
+                  <span>Add the local Supabase environment variables to enable sign-in.</span>
+                </div>
+
+                <div class="card-actions justify-start">
+                  <A class="btn btn-ghost btn-sm" href="/">
+                    Back to start
+                  </A>
+                </div>
+              </div>
+            </div>
+          }
+        >
+          <AuthForm idPrefix="login-page" showBackLink surface="card" />
+        </Show>
+      </Show>
     </main>
   );
 }

--- a/src/components/auth/authHelper.ts
+++ b/src/components/auth/authHelper.ts
@@ -1,4 +1,5 @@
 export type EnvironmentType = "local" | "deploy-preview" | "production";
+
 export const getRedirectUrl = () => {
   const environment = import.meta.env.VITE_CONTEXT ?? "local";
   switch (environment) {
@@ -12,3 +13,42 @@ export const getRedirectUrl = () => {
         : globalThis.window.location.origin;
   }
 };
+
+export function getAuthRouteUrl(path = "/login") {
+  return new URL(path, getRedirectUrl()).toString();
+}
+
+function parseUrlParams(params: URLSearchParams) {
+  return {
+    type: params.get("type"),
+    accessToken: params.get("access_token"),
+    refreshToken: params.get("refresh_token"),
+  };
+}
+
+export function isRecoveryRedirect() {
+  if (globalThis.window === undefined) {
+    return false;
+  }
+
+  const url = new URL(globalThis.window.location.href);
+  const searchState = parseUrlParams(url.searchParams);
+  const hashState = parseUrlParams(new URLSearchParams(url.hash.replace(/^#/, "")));
+
+  return (
+    searchState.type === "recovery" ||
+    hashState.type === "recovery" ||
+    Boolean(hashState.accessToken && hashState.refreshToken)
+  );
+}
+
+export function clearAuthRedirectState() {
+  if (globalThis.window === undefined) {
+    return;
+  }
+
+  const url = new URL(globalThis.window.location.href);
+  url.hash = "";
+  url.searchParams.delete("type");
+  globalThis.window.history.replaceState({}, document.title, url.toString());
+}

--- a/src/routes/MainLayout.tsx
+++ b/src/routes/MainLayout.tsx
@@ -10,7 +10,7 @@ const PUBLIC_PATHS = new Set(["/login"]);
 export const MainLayout: ParentComponent = (props) => {
   const location = useLocation();
   const navigate = useNavigate();
-  const { loading, session } = useAuthSession();
+  const { loading, recoveryMode, session } = useAuthSession();
 
   const isPublicRoute = () => PUBLIC_PATHS.has(location.pathname);
 
@@ -22,7 +22,7 @@ export const MainLayout: ParentComponent = (props) => {
       return;
     }
 
-    if (session() && location.pathname === "/login") {
+    if (session() && location.pathname === "/login" && !recoveryMode()) {
       navigate("/", { replace: true });
     }
   });
@@ -39,7 +39,9 @@ export const MainLayout: ParentComponent = (props) => {
             </div>
           </Match>
           <Match when={isPublicRoute() || session()}>
-            <Show when={!(session() && location.pathname === "/login")}>{props.children}</Show>
+            <Show when={!(session() && location.pathname === "/login" && !recoveryMode())}>
+              {props.children}
+            </Show>
           </Match>
           <Match when={true}>
             <div class="flex min-h-full items-center justify-center">


### PR DESCRIPTION
## Summary
- replace the hosted Supabase auth widget with a custom Solid auth UI built with DaisyUI
- add email/password, Google, sign up, forgot password, and reset password flows on the shared auth surface
- add Playwright coverage for auth mode switching and recovery-mode entry on /login

## Verification
- npx pnpm@10 lint
- npx pnpm@10 build
- npx pnpm@10 test:e2e

Closes #14