### PR TITLE
feat: add match scoring RPCs and refactor frontend to event-based model (#37)

### DIFF
--- a/src/components/ProtectedApp.tsx
+++ b/src/components/ProtectedApp.tsx
@@ -13,7 +13,7 @@ import type { Tables } from "~/types/database.ts";
 import "../App.css";
 
 type MatchRow = Tables<"matches">;
-type GoalRow = Tables<"goals">;
+type MatchEventRow = Tables<"match_events">;
 
 export default function ProtectedApp() {
   const [settings, setSettings] = createLocalStorageStore<ISettings>("settings", {
@@ -23,7 +23,7 @@ export default function ProtectedApp() {
   });
   const [availableTeams] = createResource(getAllTeams);
   const [currentMatch, setCurrentMatch] = createSignal<MatchRow | null>(null);
-  const [goals, setGoals] = createSignal<GoalRow[]>([]);
+  const [matchEvents, setMatchEvents] = createSignal<MatchEventRow[]>([]);
   const [isPaused, setIsPaused] = createSignal(false);
   const [leaderboardRefreshKey, setLeaderboardRefreshKey] = createSignal(0);
   const { elapsedTime, reset, running, start, stop } = useGameTimer();
@@ -50,20 +50,32 @@ export default function ProtectedApp() {
     if (!match) return;
 
     setCurrentMatch(match);
-    setGoals(await matchService.fetchGoalsForMatch(match.id));
+    setMatchEvents(await matchService.fetchMatchEvents(match.id));
     await syncSettingsWithMatch(match);
     setIsPaused(false);
     start();
   };
 
-  const handleGoalInsert = (newGoal: GoalRow) => {
-    setGoals((prev) => (prev.some((goal) => goal.id === newGoal.id) ? prev : [...prev, newGoal]));
-    playSound("goal");
+  const handleEventInsert = (event: MatchEventRow) => {
+    setMatchEvents((prev) => (prev.some((e) => e.id === event.id) ? prev : [...prev, event]));
+    if (event.type === "goal_detected" && event.status === "valid") {
+      playSound("goal");
+    }
   };
 
-  const handleGoalDelete = (goalId: number) => {
-    setGoals((prev) => prev.filter((goal) => goal.id !== goalId));
-    playSound("no-goal");
+  const handleEventUpdate = (updatedEvent: MatchEventRow) => {
+    setMatchEvents((prev) => {
+      const oldEvent = prev.find((e) => e.id === updatedEvent.id);
+      const wasValidGoal = oldEvent?.type === "goal_detected" && oldEvent?.status === "valid";
+      const isNoLongerValid =
+        updatedEvent.type === "goal_detected" && updatedEvent.status !== "valid";
+
+      if (wasValidGoal && isNoLongerValid) {
+        playSound("no-goal");
+      }
+
+      return prev.map((e) => (e.id === updatedEvent.id ? updatedEvent : e));
+    });
   };
 
   const startGame = async () => {
@@ -81,7 +93,7 @@ export default function ProtectedApp() {
 
     reset();
     setCurrentMatch(match);
-    setGoals([]);
+    setMatchEvents([]);
     setIsPaused(false);
     start();
   };
@@ -91,11 +103,16 @@ export default function ProtectedApp() {
     if (!match || !running() || isPaused()) return;
 
     if (increment > 0) {
-      await matchService.recordGoal(match.id, teamId, elapsedTime(), matchService.formatGoalTime);
+      await matchService.recordGoalEvent(
+        match.id,
+        teamId,
+        elapsedTime(),
+        matchService.formatGoalTime
+      );
       return;
     }
 
-    await matchService.removeLastGoal(match.id, teamId);
+    await matchService.invalidateLastGoalForTeam(match.id, teamId, "manual correction");
   };
 
   const finalizeCurrentMatch = async (matchId: number) => {
@@ -119,7 +136,7 @@ export default function ProtectedApp() {
     stop();
     setIsPaused(false);
     reset();
-    setGoals([]);
+    setMatchEvents([]);
     setCurrentMatch(null);
   };
 
@@ -134,6 +151,13 @@ export default function ProtectedApp() {
     setIsPaused(true);
   };
 
+  const countValidGoals = (teamId: number | undefined) => {
+    if (!teamId) return 0;
+    return matchEvents().filter(
+      (e) => e.type === "goal_detected" && e.status === "valid" && e.team_id === teamId
+    ).length;
+  };
+
   onMount(() => {
     void hydrateActiveMatch();
     onCleanup(() => stop());
@@ -142,7 +166,7 @@ export default function ProtectedApp() {
   createEffect(() => {
     const match = currentMatch();
     if (match?.in_progress) {
-      useMatchSubscription(match.id, handleGoalInsert, handleGoalDelete);
+      useMatchSubscription(match.id, handleEventInsert, handleEventUpdate);
     }
   });
 
@@ -150,8 +174,8 @@ export default function ProtectedApp() {
     const match = currentMatch();
     if (!match?.in_progress || isPaused()) return;
 
-    const yellowScore = goals().filter((goal) => goal.team_id === settings.yellowTeam.id).length;
-    const blackScore = goals().filter((goal) => goal.team_id === settings.blackTeam.id).length;
+    const yellowScore = countValidGoals(settings.yellowTeam.id);
+    const blackScore = countValidGoals(settings.blackTeam.id);
 
     if (yellowScore < settings.goalsToWin && blackScore < settings.goalsToWin) return;
 
@@ -185,7 +209,7 @@ export default function ProtectedApp() {
           <MatchDashboard
             currentMatch={match}
             elapsedTime={elapsedTime()}
-            goals={goals()}
+            matchEvents={matchEvents()}
             isPaused={isPaused()}
             leaderboardRefreshKey={leaderboardRefreshKey()}
             onAdjustGoal={adjustGoal}

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -16,13 +16,13 @@ import { formatTime } from "~/lib/utils.ts";
 import type { ISettings } from "~/types/Settings";
 import type { Tables } from "~/types/database";
 
-type GoalRow = Tables<"goals">;
+type MatchEventRow = Tables<"match_events">;
 type MatchRow = Tables<"matches">;
 
 interface ScoreBoardProps {
   currentMatch: MatchRow;
   elapsedTime: number;
-  goals: GoalRow[];
+  matchEvents: MatchEventRow[];
   isPaused: boolean;
   onAdjustGoal: (teamId: number, increment: number) => Promise<void>;
   onResetGame: () => Promise<void>;
@@ -35,10 +35,22 @@ export function ScoreBoard(props: Readonly<ScoreBoardProps>) {
   let scoreboardElement: HTMLElement | undefined;
 
   const yellowScore = createMemo(
-    () => props.goals.filter((goal) => goal.team_id === props.settings.yellowTeam.id).length
+    () =>
+      props.matchEvents.filter(
+        (e) =>
+          e.type === "goal_detected" &&
+          e.status === "valid" &&
+          e.team_id === props.settings.yellowTeam.id
+      ).length
   );
   const blackScore = createMemo(
-    () => props.goals.filter((goal) => goal.team_id === props.settings.blackTeam.id).length
+    () =>
+      props.matchEvents.filter(
+        (e) =>
+          e.type === "goal_detected" &&
+          e.status === "valid" &&
+          e.team_id === props.settings.blackTeam.id
+      ).length
   );
 
   const scoreboardDisabled = () => props.isPaused;
@@ -114,6 +126,8 @@ export function ScoreBoard(props: Readonly<ScoreBoardProps>) {
     props.isPaused ? "badge badge-warning gap-2" : "badge badge-success gap-2";
 
   const recentGoalLimit = () => (isFullscreen() ? 4 : 0);
+
+  const goalEvents = createMemo(() => props.matchEvents.filter((e) => e.type === "goal_detected"));
 
   const centerScore = () => (
     <div class="border-base-300 bg-base-200 text-base-content [html[data-theme=dim]_&]:bg-base-100/10 [html[data-theme=dim]_&]:text-neutral-content rounded-box border px-3 py-2 shadow-sm sm:px-6 sm:py-4">
@@ -226,14 +240,14 @@ export function ScoreBoard(props: Readonly<ScoreBoardProps>) {
                 </p>
               </div>
               <span class="badge badge-outline badge-sm border-base-300 bg-base-100 [html[data-theme=dim]_&]:bg-base-100/10 [html[data-theme=dim]_&]:text-neutral-content">
-                {Math.min(props.goals.length, recentGoalLimit())} shown
+                {Math.min(goalEvents().length, recentGoalLimit())} shown
               </span>
             </div>
             <div class="max-h-64 overflow-y-auto pr-1">
               <GoalHistoryCard
                 blackTeamId={props.settings.blackTeam.id}
                 blackTeamName={blackTeamName()}
-                goals={props.goals}
+                events={goalEvents()}
                 maxItems={recentGoalLimit()}
                 showHeader={false}
                 yellowTeamId={props.settings.yellowTeam.id}

--- a/src/components/home/GoalHistoryCard.tsx
+++ b/src/components/home/GoalHistoryCard.tsx
@@ -108,7 +108,7 @@ export function GoalHistoryCard(props: Readonly<GoalHistoryCardProps>) {
             {(row) => (
               <div
                 class={`rounded-box border-base-300 bg-base-200 [html[data-theme=dim]_&]:bg-base-100/10 grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 border px-3 py-2.5 shadow-sm sm:px-4 ${
-                  !row.isValid ? "opacity-50" : ""
+                  row.isValid ? "" : "opacity-50"
                 }`}
               >
                 <div class="flex min-w-0 items-center gap-2">
@@ -126,19 +126,19 @@ export function GoalHistoryCard(props: Readonly<GoalHistoryCardProps>) {
                         : "border-neutral-content/20 bg-neutral text-neutral-content [html[data-theme=dim]_&]:border-neutral-content/30 [html[data-theme=dim]_&]:bg-neutral-content/12 [html[data-theme=dim]_&]:text-neutral-content"
                     }`}
                   >
-                    <span class={!row.isValid ? "line-through" : ""}>{row.teamLabel}</span>
+                    <span class={row.isValid ? "" : "line-through"}>{row.teamLabel}</span>
                   </span>
                 </div>
                 <span
                   class={`[html[data-theme=dim]_&]:text-neutral-content text-base leading-none font-black tracking-tight tabular-nums sm:text-lg ${
-                    !row.isValid ? "line-through" : ""
+                    row.isValid ? "" : "line-through"
                   }`}
                 >
                   {row.scoreLabel}
                 </span>
                 <span
                   class={`text-base-content/85 [html[data-theme=dim]_&]:text-neutral-content/90 text-sm font-bold tabular-nums ${
-                    !row.isValid ? "line-through" : ""
+                    row.isValid ? "" : "line-through"
                   }`}
                 >
                   {row.timeLabel}

--- a/src/components/home/GoalHistoryCard.tsx
+++ b/src/components/home/GoalHistoryCard.tsx
@@ -2,12 +2,12 @@ import { For, Show, createMemo } from "solid-js";
 import { History } from "lucide-solid";
 import type { Tables } from "~/types/database";
 
-type GoalRow = Tables<"goals">;
+type MatchEventRow = Tables<"match_events">;
 
 interface GoalHistoryCardProps {
   blackTeamId?: number;
   blackTeamName: string;
-  goals: GoalRow[];
+  events: MatchEventRow[];
   maxItems?: number;
   showHeader?: boolean;
   yellowTeamId?: number;
@@ -20,6 +20,7 @@ interface GoalHistoryRow {
   teamLabel: string;
   teamTone: "yellow" | "black";
   timeLabel: string;
+  isValid: boolean;
 }
 
 export function GoalHistoryCard(props: Readonly<GoalHistoryCardProps>) {
@@ -27,21 +28,27 @@ export function GoalHistoryCard(props: Readonly<GoalHistoryCardProps>) {
     let yellowScore = 0;
     let blackScore = 0;
 
-    const mappedRows = props.goals.map((goal) => {
-      const isYellow = goal.team_id === props.yellowTeamId;
+    const goalEvents = props.events.filter((e) => e.type === "goal_detected");
 
-      if (isYellow) {
-        yellowScore += 1;
-      } else {
-        blackScore += 1;
+    const mappedRows = goalEvents.map((event) => {
+      const isYellow = event.team_id === props.yellowTeamId;
+      const isCounted = event.status === "valid";
+
+      if (isCounted) {
+        if (isYellow) {
+          yellowScore += 1;
+        } else {
+          blackScore += 1;
+        }
       }
 
       return {
-        id: goal.id,
+        id: event.id,
         scoreLabel: `${yellowScore} - ${blackScore}`,
         teamLabel: isYellow ? props.yellowTeamName : props.blackTeamName,
         teamTone: isYellow ? ("yellow" as const) : ("black" as const),
-        timeLabel: goal.goal_time.replace(/^00:/, ""),
+        timeLabel: (event.goal_time ?? "").replace(/^00:/, ""),
+        isValid: isCounted,
       };
     });
 
@@ -51,7 +58,7 @@ export function GoalHistoryCard(props: Readonly<GoalHistoryCardProps>) {
   });
 
   const eventCountLabel = createMemo(() => {
-    const eventCount = props.goals.length;
+    const eventCount = rows().length;
     return `${eventCount} ${eventCount === 1 ? "event" : "events"}`;
   });
 
@@ -99,7 +106,11 @@ export function GoalHistoryCard(props: Readonly<GoalHistoryCardProps>) {
             }
           >
             {(row) => (
-              <div class="rounded-box border-base-300 bg-base-200 [html[data-theme=dim]_&]:bg-base-100/10 grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 border px-3 py-2.5 shadow-sm sm:px-4">
+              <div
+                class={`rounded-box border-base-300 bg-base-200 [html[data-theme=dim]_&]:bg-base-100/10 grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 border px-3 py-2.5 shadow-sm sm:px-4 ${
+                  !row.isValid ? "opacity-50" : ""
+                }`}
+              >
                 <div class="flex min-w-0 items-center gap-2">
                   <span
                     class={`h-3 w-3 shrink-0 rounded-full border ${
@@ -115,13 +126,21 @@ export function GoalHistoryCard(props: Readonly<GoalHistoryCardProps>) {
                         : "border-neutral-content/20 bg-neutral text-neutral-content [html[data-theme=dim]_&]:border-neutral-content/30 [html[data-theme=dim]_&]:bg-neutral-content/12 [html[data-theme=dim]_&]:text-neutral-content"
                     }`}
                   >
-                    {row.teamLabel}
+                    <span class={!row.isValid ? "line-through" : ""}>{row.teamLabel}</span>
                   </span>
                 </div>
-                <span class="[html[data-theme=dim]_&]:text-neutral-content text-base leading-none font-black tracking-tight tabular-nums sm:text-lg">
+                <span
+                  class={`[html[data-theme=dim]_&]:text-neutral-content text-base leading-none font-black tracking-tight tabular-nums sm:text-lg ${
+                    !row.isValid ? "line-through" : ""
+                  }`}
+                >
                   {row.scoreLabel}
                 </span>
-                <span class="text-base-content/85 [html[data-theme=dim]_&]:text-neutral-content/90 text-sm font-bold tabular-nums">
+                <span
+                  class={`text-base-content/85 [html[data-theme=dim]_&]:text-neutral-content/90 text-sm font-bold tabular-nums ${
+                    !row.isValid ? "line-through" : ""
+                  }`}
+                >
                   {row.timeLabel}
                 </span>
               </div>

--- a/src/components/home/MatchDashboard.tsx
+++ b/src/components/home/MatchDashboard.tsx
@@ -5,12 +5,12 @@ import type { ISettings } from "~/types/Settings";
 import type { Tables } from "~/types/database";
 
 type MatchRow = Tables<"matches">;
-type GoalRow = Tables<"goals">;
+type MatchEventRow = Tables<"match_events">;
 
 interface MatchDashboardProps {
   currentMatch: MatchRow;
   elapsedTime: number;
-  goals: GoalRow[];
+  matchEvents: MatchEventRow[];
   isPaused: boolean;
   leaderboardRefreshKey: number;
   onAdjustGoal: (teamId: number, increment: number) => Promise<void>;
@@ -26,7 +26,7 @@ export function MatchDashboard(props: Readonly<MatchDashboardProps>) {
         <ScoreBoard
           currentMatch={props.currentMatch}
           elapsedTime={props.elapsedTime}
-          goals={props.goals}
+          matchEvents={props.matchEvents}
           isPaused={props.isPaused}
           onAdjustGoal={props.onAdjustGoal}
           onResetGame={props.onResetGame}
@@ -36,7 +36,7 @@ export function MatchDashboard(props: Readonly<MatchDashboardProps>) {
         <GoalHistoryCard
           blackTeamId={props.settings.blackTeam.id}
           blackTeamName={props.settings.blackTeam.name}
-          goals={props.goals}
+          events={props.matchEvents}
           yellowTeamId={props.settings.yellowTeam.id}
           yellowTeamName={props.settings.yellowTeam.name}
         />

--- a/src/hooks/useMatchSubscription.ts
+++ b/src/hooks/useMatchSubscription.ts
@@ -1,29 +1,36 @@
-// src/hooks/useMatchSubscription.ts
 import { onCleanup } from "solid-js";
 import { supabase } from "~/service/supabaseService";
 import type { Tables } from "~/types/database";
 
-type GoalsRow = Tables<"goals">;
+type MatchEventRow = Tables<"match_events">;
 
 export function useMatchSubscription(
   matchId: number,
-  onGoalInsert: (goal: GoalsRow) => void,
-  onGoalDelete: (goalId: number) => void
+  onEventInsert: (event: MatchEventRow) => void,
+  onEventUpdate: (event: MatchEventRow) => void
 ) {
   if (!supabase) return;
   const channel = supabase
-    .channel(`match_goals_${matchId}`)
-    .on("postgres_changes", { event: "INSERT", schema: "public", table: "goals" }, (payload) => {
-      const newGoal = payload.new as GoalsRow;
-      if (newGoal.match_id === matchId) onGoalInsert(newGoal);
-    })
-    .on("postgres_changes", { event: "DELETE", schema: "public", table: "goals" }, (payload) => {
-      const oldGoalId = payload.old.id;
-      if (oldGoalId) onGoalDelete(oldGoalId);
-    })
+    .channel(`match_events_${matchId}`)
+    .on(
+      "postgres_changes",
+      { event: "INSERT", schema: "public", table: "match_events" },
+      (payload) => {
+        const newEvent = payload.new as MatchEventRow;
+        if (newEvent.match_id === matchId) onEventInsert(newEvent);
+      }
+    )
+    .on(
+      "postgres_changes",
+      { event: "UPDATE", schema: "public", table: "match_events" },
+      (payload) => {
+        const updatedEvent = payload.new as MatchEventRow;
+        if (updatedEvent.match_id === matchId) onEventUpdate(updatedEvent);
+      }
+    )
     .subscribe();
 
   onCleanup(() => {
-    channel.unsubscribe().then(() => console.info("Unsubscribed from match goals"));
+    channel.unsubscribe().then(() => console.info("Unsubscribed from match events"));
   });
 }

--- a/src/service/leaderboardService.ts
+++ b/src/service/leaderboardService.ts
@@ -2,7 +2,7 @@ import { supabase } from "~/service/supabaseService";
 import type { Tables } from "~/types/database";
 
 type MatchRow = Tables<"matches">;
-type GoalRow = Tables<"goals">;
+type MatchEventRow = Tables<"match_events">;
 type TeamRow = Tables<"teams">;
 type PlayerRow = Tables<"players">;
 type TeamMemberRow = Tables<"team_members">;
@@ -30,32 +30,31 @@ export async function getLeaderboardSnapshot(): Promise<LeaderboardSnapshot> {
     return { teams: [], players: [] };
   }
 
-  const [matchesResult, goalsResult, teamsResult, playersResult, membersResult] = await Promise.all(
-    [
+  const [matchesResult, eventsResult, teamsResult, playersResult, membersResult] =
+    await Promise.all([
       supabase.from("matches").select("*").eq("in_progress", false),
-      supabase.from("goals").select("*"),
+      supabase.from("match_events").select("*"),
       supabase.from("teams").select("*"),
       supabase.from("players").select("*"),
       supabase.from("team_members").select("*"),
-    ]
-  );
+    ]);
 
   if (matchesResult.error) {
     console.error("Error fetching completed matches:", matchesResult.error);
     return { teams: [], players: [] };
   }
 
-  if (goalsResult.error || teamsResult.error || playersResult.error || membersResult.error) {
+  if (eventsResult.error || teamsResult.error || playersResult.error || membersResult.error) {
     console.error(
       "Error fetching leaderboard dependencies:",
-      goalsResult.error ?? teamsResult.error ?? playersResult.error ?? membersResult.error
+      eventsResult.error ?? teamsResult.error ?? playersResult.error ?? membersResult.error
     );
     return { teams: [], players: [] };
   }
 
   return buildLeaderboardSnapshot({
     matches: matchesResult.data ?? [],
-    goals: goalsResult.data ?? [],
+    events: eventsResult.data ?? [],
     teams: teamsResult.data ?? [],
     players: playersResult.data ?? [],
     teamMembers: membersResult.data ?? [],
@@ -64,19 +63,19 @@ export async function getLeaderboardSnapshot(): Promise<LeaderboardSnapshot> {
 
 function buildLeaderboardSnapshot(input: {
   matches: MatchRow[];
-  goals: GoalRow[];
+  events: MatchEventRow[];
   players: PlayerRow[];
   teamMembers: TeamMemberRow[];
   teams: TeamRow[];
 }): LeaderboardSnapshot {
   const teamById = new Map(input.teams.map((team) => [team.id, team]));
-  const goalsByMatch = groupGoalsByMatch(input.goals);
+  const eventsByMatch = groupValidGoalEventsByMatch(input.events);
   const teamMembersByTeamId = groupTeamMembersByTeam(input.teamMembers);
   const teamWins = new Map<number, number>();
   const playerWins = new Map<number, number>();
 
   for (const match of input.matches) {
-    const winnerId = getWinnerId(match, goalsByMatch.get(match.id) ?? []);
+    const winnerId = getWinnerId(match, eventsByMatch.get(match.id) ?? []);
     if (!winnerId) continue;
     teamWins.set(winnerId, (teamWins.get(winnerId) ?? 0) + 1);
     addPlayerWinsForTeam(winnerId, teamById, teamMembersByTeamId, playerWins);
@@ -103,16 +102,17 @@ function buildLeaderboardSnapshot(input: {
   return { teams, players };
 }
 
-function groupGoalsByMatch(goals: GoalRow[]) {
-  const goalsByMatch = new Map<number, GoalRow[]>();
+function groupValidGoalEventsByMatch(events: MatchEventRow[]) {
+  const eventsByMatch = new Map<number, MatchEventRow[]>();
 
-  for (const goal of goals) {
-    const existing = goalsByMatch.get(goal.match_id) ?? [];
-    existing.push(goal);
-    goalsByMatch.set(goal.match_id, existing);
+  for (const event of events) {
+    if (event.type !== "goal_detected" || event.status !== "valid") continue;
+    const existing = eventsByMatch.get(event.match_id) ?? [];
+    existing.push(event);
+    eventsByMatch.set(event.match_id, existing);
   }
 
-  return goalsByMatch;
+  return eventsByMatch;
 }
 
 function groupTeamMembersByTeam(teamMembers: TeamMemberRow[]) {
@@ -127,11 +127,11 @@ function groupTeamMembersByTeam(teamMembers: TeamMemberRow[]) {
   return teamMembersByTeamId;
 }
 
-function getWinnerId(match: MatchRow, matchGoals: GoalRow[]) {
+function getWinnerId(match: MatchRow, matchEvents: MatchEventRow[]) {
   const scoreByTeam = new Map<number, number>();
 
-  for (const goal of matchGoals) {
-    scoreByTeam.set(goal.team_id, (scoreByTeam.get(goal.team_id) ?? 0) + 1);
+  for (const event of matchEvents) {
+    scoreByTeam.set(event.team_id, (scoreByTeam.get(event.team_id) ?? 0) + 1);
   }
 
   const homeScore = scoreByTeam.get(match.home_team_id) ?? 0;

--- a/src/service/matchService.ts
+++ b/src/service/matchService.ts
@@ -1,9 +1,9 @@
-// src/services/matchService.ts
 import { requireSupabase, supabase } from "~/service/supabaseService";
 import type { Tables } from "~/types/database";
 
 type GoalsRow = Tables<"goals">;
 type MatchesRow = Tables<"matches">;
+type MatchEventRow = Tables<"match_events">;
 
 export function formatGoalTime(seconds: number) {
   const minutes = Math.floor(seconds / 60);
@@ -29,37 +29,93 @@ export async function createMatch(
   return data;
 }
 
-export async function recordGoal(
+export async function recordGoalEvent(
   matchId: number,
   teamId: number,
   timer: number,
   formatTime: (seconds: number) => string
-) {
+): Promise<number | null> {
   const client = requireSupabase();
   const goalTime = formatTime(timer);
-  const { error } = await client.from("goals").insert({
-    match_id: matchId,
-    team_id: teamId,
-    goal_time: goalTime,
+  const { data, error } = await client.rpc("record_goal_event", {
+    p_match_id: matchId,
+    p_team_id: teamId,
+    p_source: "web",
+    p_source_id: undefined,
+    p_goal_time: goalTime,
   });
-  if (error) console.error("Error recording goal:", error);
+  if (error) {
+    console.error("Error recording goal event:", error);
+    return null;
+  }
+  return data;
 }
 
-export async function removeLastGoal(matchId: number, teamId: number) {
+export async function invalidateGoalEvent(
+  eventId: number,
+  reason?: string
+): Promise<number | null> {
   const client = requireSupabase();
-  const { data: foundGoals, error: fetchErr } = await client
-    .from("goals")
-    .select("*")
+  const { data, error } = await client.rpc("invalidate_goal_event", {
+    p_event_id: eventId,
+    p_reason: reason ?? undefined,
+  });
+  if (error) {
+    console.error("Error invalidating goal event:", error);
+    return null;
+  }
+  return data;
+}
+
+export async function invalidateLastGoalForTeam(
+  matchId: number,
+  teamId: number,
+  reason?: string
+): Promise<number | null> {
+  const client = requireSupabase();
+  const { data } = await client
+    .from("match_events")
+    .select("id")
     .eq("match_id", matchId)
     .eq("team_id", teamId)
+    .eq("type", "goal_detected")
+    .eq("status", "valid")
     .order("created_at", { ascending: false })
     .limit(1);
-  if (fetchErr || !foundGoals?.length) {
-    console.error("Error fetching last goal:", fetchErr);
-    return;
+
+  if (!data?.length) {
+    console.warn("No valid goal to invalidate for team", teamId);
+    return null;
   }
-  const { error: deleteErr } = await client.from("goals").delete().eq("id", foundGoals[0].id);
-  if (deleteErr) console.error("Error deleting goal:", deleteErr);
+
+  return invalidateGoalEvent(data[0].id, reason);
+}
+
+export async function resetMatchScore(matchId: number, reason?: string): Promise<number | null> {
+  const client = requireSupabase();
+  const { data, error } = await client.rpc("reset_match_score", {
+    p_match_id: matchId,
+    p_reason: reason ?? undefined,
+  });
+  if (error) {
+    console.error("Error resetting match score:", error);
+    return null;
+  }
+  return data;
+}
+
+export async function fetchMatchEvents(matchId: number): Promise<MatchEventRow[]> {
+  if (!supabase) return [];
+  const { data, error } = await supabase
+    .from("match_events")
+    .select("*")
+    .eq("match_id", matchId)
+    .order("created_at");
+  if (error) {
+    console.error("Error fetching match events:", error);
+    return [];
+  }
+  return data;
 }
 
 export async function fetchGoalsForMatch(matchId: number): Promise<GoalsRow[]> {
@@ -103,6 +159,12 @@ export async function endGame(matchId: number) {
 
 export async function abandonMatch(matchId: number) {
   const client = requireSupabase();
+
+  const { error: eventsError } = await client.from("match_events").delete().eq("match_id", matchId);
+  if (eventsError) {
+    console.error("Error deleting abandoned match events:", eventsError);
+    return false;
+  }
 
   const { error: goalsError } = await client.from("goals").delete().eq("match_id", matchId);
   if (goalsError) {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -297,7 +297,28 @@ export type Database = {
           team_id: number;
         }[];
       };
+      invalidate_goal_event: {
+        Args: { p_event_id: number; p_reason?: string };
+        Returns: number;
+      };
       is_admin: { Args: never; Returns: boolean };
+      record_goal_event: {
+        Args: {
+          p_dedupe_key?: string;
+          p_goal_time?: string;
+          p_match_id: number;
+          p_metadata?: Json;
+          p_player_id?: number;
+          p_source: Database["public"]["Enums"]["match_event_source"];
+          p_source_id?: string;
+          p_team_id: number;
+        };
+        Returns: number;
+      };
+      reset_match_score: {
+        Args: { p_match_id: number; p_reason?: string };
+        Returns: number;
+      };
       update_team_with_members: {
         Args: {
           target_name: string;

--- a/supabase/migrations/20260601160036_match_scoring_rpcs.sql
+++ b/supabase/migrations/20260601160036_match_scoring_rpcs.sql
@@ -1,0 +1,187 @@
+-- =====================================================
+-- 1. record_goal_event
+-- Atomically insert a goal_detected event.
+-- Validates match is active. Returns existing event id
+-- if dedupe_key is provided and already exists.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.record_goal_event(
+  p_match_id bigint,
+  p_team_id bigint,
+  p_source match_event_source,
+  p_source_id text DEFAULT NULL,
+  p_dedupe_key text DEFAULT NULL,
+  p_goal_time interval DEFAULT NULL,
+  p_metadata jsonb DEFAULT NULL,
+  p_player_id bigint DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+DECLARE
+  v_match_in_progress boolean;
+  v_event_id bigint;
+BEGIN
+  SELECT in_progress INTO v_match_in_progress
+  FROM public.matches
+  WHERE id = p_match_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Match % not found', p_match_id;
+  END IF;
+
+  IF NOT v_match_in_progress THEN
+    RAISE EXCEPTION 'Match % is not in progress', p_match_id;
+  END IF;
+
+  IF p_dedupe_key IS NOT NULL THEN
+    SELECT id INTO v_event_id
+    FROM public.match_events
+    WHERE dedupe_key = p_dedupe_key;
+    IF FOUND THEN
+      RETURN v_event_id;
+    END IF;
+  END IF;
+
+  INSERT INTO public.match_events (
+    match_id, type, team_id, player_id, source, source_id,
+    dedupe_key, status, goal_time, metadata
+  ) VALUES (
+    p_match_id, 'goal_detected', p_team_id, p_player_id, p_source, p_source_id,
+    p_dedupe_key, 'valid', p_goal_time, p_metadata
+  )
+  RETURNING id INTO v_event_id;
+
+  RETURN v_event_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.record_goal_event IS
+  'Atomically record a goal_detected event. Validates the match is active. Returns the existing event id when the dedupe_key is already present (idempotent).';
+
+-- =====================================================
+-- 2. invalidate_goal_event
+-- Mark a goal_detected event as invalid and create a
+-- manual_correction event pointing back to it.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.invalidate_goal_event(
+  p_event_id bigint,
+  p_reason text DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+DECLARE
+  v_event public.match_events%ROWTYPE;
+  v_match_in_progress boolean;
+  v_correction_id bigint;
+BEGIN
+  SELECT * INTO v_event
+  FROM public.match_events
+  WHERE id = p_event_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Event % not found', p_event_id;
+  END IF;
+
+  IF v_event.type != 'goal_detected' THEN
+    RAISE EXCEPTION 'Event % is not a goal_detected event', p_event_id;
+  END IF;
+
+  IF v_event.status != 'valid' THEN
+    RAISE EXCEPTION 'Event % is already %', p_event_id, v_event.status;
+  END IF;
+
+  SELECT in_progress INTO v_match_in_progress
+  FROM public.matches
+  WHERE id = v_event.match_id;
+
+  IF NOT v_match_in_progress THEN
+    RAISE EXCEPTION 'Match % is not in progress', v_event.match_id;
+  END IF;
+
+  UPDATE public.match_events
+  SET status = 'invalid'
+  WHERE id = p_event_id;
+
+  INSERT INTO public.match_events (
+    match_id, type, team_id, player_id, source, source_id,
+    status, goal_time, related_event_id, metadata
+  ) VALUES (
+    v_event.match_id, 'manual_correction', v_event.team_id, v_event.player_id,
+    'web', auth.uid()::text, 'valid', v_event.goal_time, p_event_id,
+    jsonb_build_object('reason', p_reason, 'action', 'invalidated goal event')
+  )
+  RETURNING id INTO v_correction_id;
+
+  RETURN v_correction_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.invalidate_goal_event IS
+  'Mark a goal_detected event as invalid and insert a corresponding manual_correction event. Returns the correction event id.';
+
+-- =====================================================
+-- 3. reset_match_score
+-- Mark all valid goal_detected events for the match as
+-- removed and insert a score_reset event.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.reset_match_score(
+  p_match_id bigint,
+  p_reason text DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+DECLARE
+  v_match_in_progress boolean;
+  v_reset_event_id bigint;
+  v_home_team_id bigint;
+BEGIN
+  SELECT in_progress, home_team_id INTO v_match_in_progress, v_home_team_id
+  FROM public.matches
+  WHERE id = p_match_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Match % not found', p_match_id;
+  END IF;
+
+  IF NOT v_match_in_progress THEN
+    RAISE EXCEPTION 'Match % is not in progress', p_match_id;
+  END IF;
+
+  UPDATE public.match_events
+  SET status = 'removed'
+  WHERE match_id = p_match_id
+    AND type = 'goal_detected'
+    AND status = 'valid';
+
+  INSERT INTO public.match_events (
+    match_id, type, team_id, source, source_id, status, metadata
+  ) VALUES (
+    p_match_id, 'score_reset', v_home_team_id,
+    'web', auth.uid()::text, 'valid',
+    jsonb_build_object('reason', p_reason)
+  )
+  RETURNING id INTO v_reset_event_id;
+
+  RETURN v_reset_event_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.reset_match_score IS
+  'Mark all valid goal_detected events for a match as removed and insert a score_reset event. Returns the reset event id.';
+
+-- =====================================================
+-- 4. Permissions
+-- =====================================================
+
+GRANT EXECUTE ON FUNCTION public.record_goal_event TO authenticated, anon;
+GRANT EXECUTE ON FUNCTION public.invalidate_goal_event TO authenticated, anon;
+GRANT EXECUTE ON FUNCTION public.reset_match_score TO authenticated, anon;

--- a/supabase/migrations/20260601164253_fix_atomic_dedupe.sql
+++ b/supabase/migrations/20260601164253_fix_atomic_dedupe.sql
@@ -1,0 +1,57 @@
+-- Replace record_goal_event with an atomic version that uses
+-- EXCEPTION-based deduplication instead of a SELECT-then-INSERT
+-- pattern. This prevents a race condition where two concurrent
+-- requests with the same dedupe_key could both pass the pre-check
+-- before either row becomes visible.
+
+CREATE OR REPLACE FUNCTION public.record_goal_event(
+  p_match_id bigint,
+  p_team_id bigint,
+  p_source match_event_source,
+  p_source_id text DEFAULT NULL,
+  p_dedupe_key text DEFAULT NULL,
+  p_goal_time interval DEFAULT NULL,
+  p_metadata jsonb DEFAULT NULL,
+  p_player_id bigint DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+DECLARE
+  v_match_in_progress boolean;
+  v_event_id bigint;
+BEGIN
+  SELECT in_progress INTO v_match_in_progress
+  FROM public.matches
+  WHERE id = p_match_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Match % not found', p_match_id;
+  END IF;
+
+  IF NOT v_match_in_progress THEN
+    RAISE EXCEPTION 'Match % is not in progress', p_match_id;
+  END IF;
+
+  INSERT INTO public.match_events (
+    match_id, type, team_id, player_id, source, source_id,
+    dedupe_key, status, goal_time, metadata
+  ) VALUES (
+    p_match_id, 'goal_detected', p_team_id, p_player_id, p_source, p_source_id,
+    p_dedupe_key, 'valid', p_goal_time, p_metadata
+  )
+  RETURNING id INTO v_event_id;
+
+  RETURN v_event_id;
+EXCEPTION
+  WHEN unique_violation THEN
+    SELECT id INTO v_event_id
+    FROM public.match_events
+    WHERE dedupe_key = p_dedupe_key;
+    RETURN v_event_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.record_goal_event IS
+  'Atomically record a goal_detected event. Validates the match is active. Uses unique_violation exception handling to make dedupe idempotent even under concurrent retries.';


### PR DESCRIPTION
Closes #37
Closes #38

## Summary

### Database RPCs (migration `20260601160036_match_scoring_rpcs.sql`)
- `record_goal_event` — Atomically insert goal_detected events with match-activity validation and dedup-key idempotency
- `invalidate_goal_event` — Mark event invalid + insert manual_correction event in one transaction
- `reset_match_score` — Mark all valid goals as removed + insert score_reset event

### Frontend refactor
- Replaced direct `goals` table writes with typed RPC service wrappers in `matchService.ts`
- Switched realtime subscription from `goals` to `match_events` (INSERT + UPDATE)
- ScoreBoard and GoalHistoryCard now derive scores from valid goal_detected events with visual status indicators
- LeaderboardService uses `match_events` for winner/score calculation
- Audio feedback gated on valid goal events only
- `abandonMatch` cleans up both `goals` and `match_events`

### Testing
- RPCs verified via psql: idempotent dedup, invalidation with correction, reset
- `pnpm lint` ✓
- `pnpm format:check` ✓
- `pnpm build` ✓