### PR TITLE
chore: clarify local-first Supabase CLI approach and GitHub integration deployment (#53)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,9 @@ Impeccable skills are installed at `.agents/skills/impeccable/` (for OpenCode/lo
 ### CLI Link State
 
 - The Supabase CLI is **not linked to production** by default. Migration work, type generation, and testing all run against the local instance.
-- Migrations reach production through the **Supabase GitHub integration**: preview branch is created on PR push, migrations auto-apply there, and they auto-apply to production when the PR is merged to `main`. No manual push needed.
+- The project is on Supabase **free tier** — there is no database branching. The Netlify deploy preview shares the production Supabase database. Migrations only apply when the PR is merged to `main` via Supabase GitHub integration.
+- Features depending on pending migrations may not work in the Netlify preview. That is expected. Test migrations locally (`pnpm db:reset`) as the primary verification step.
+- If you need the preview to work before merge, you can manually apply migrations to production with `pnpm supabase:link:prod && pnpm db:push:remote`. Unlink after.
 - Do not run `supabase db push` (or `pnpm db:push:remote`) unless the user explicitly asks.
 - If you need to query production for debugging, temporarily link with `supabase link --project-ref eucjxbcicejyinubzgwh`, do your work, then `supabase unlink`. Never leave the CLI linked to production.
 - All Supabase MCP queries should target the local instance when it is running.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,12 @@
 
 **ALWAYS follow [`WORKFLOW.md`](./WORKFLOW.md)** from start to finish. It covers branch naming, commits, pre-commit checks, PR creation, Codex review, SonarQube checks, and merge. Do not skip steps or invent your own workflow.
 
+**Before reading any code or starting any work:**
+
+1. Pull latest `main` and create a feature branch as described in `WORKFLOW.md` step 2.
+2. Only then explore code, read files, or make changes. Skipping this step means you may be reading stale code.
+3. If you start reading code without branching first, stop, branch, and re-read.
+
 For UI changes, also follow [`docs/ai-ui-workflow.md`](./docs/ai-ui-workflow.md) exactly — including Playwright inspection at both viewports, proof capture, and proof publication.
 
 ## Stack
@@ -73,7 +79,13 @@ Impeccable skills are installed at `.agents/skills/impeccable/` (for OpenCode/lo
 - Test migration changes with `pnpm db:reset`.
 - Regenerate types after schema changes with `pnpm db-types`.
 - Avoid remote writes unless explicitly requested by the user.
-- Do not run `supabase db push` unless the user explicitly asks.
+
+### CLI Link State
+
+- The Supabase CLI is **not linked to production** by default. Migration work, type generation, and testing all run against the local instance.
+- Migrations reach production through the **Supabase GitHub integration**: preview branch is created on PR push, migrations auto-apply there, and they auto-apply to production when the PR is merged to `main`. No manual push needed.
+- Do not run `supabase db push` (or `pnpm db:push:remote`) unless the user explicitly asks.
+- If you need to query production for debugging, temporarily link with `supabase link --project-ref eucjxbcicejyinubzgwh`, do your work, then `supabase unlink`. Never leave the CLI linked to production.
 - All Supabase MCP queries should target the local instance when it is running.
 
 ## Working Rules

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ pnpm db:reset
 pnpm db-types
 ```
 
-Migrations are deployed to production automatically via Supabase GitHub integration when PRs are merged to `main`. No manual `supabase db push` is needed.
+Test migrations locally (`pnpm db:reset`) as the primary verification step. On the free tier, the Netlify deploy preview shares the production Supabase database, and migrations are applied when the PR is merged to `main` via Supabase GitHub integration.
 
 Ask before any schema, migration, RLS, or non-local data change. Full guidance lives in [docs/supabase-local-dev.md](./docs/supabase-local-dev.md) and [AGENTS.md](./AGENTS.md).
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ pnpm db:reset
 pnpm db-types
 ```
 
+Migrations are deployed to production automatically via Supabase GitHub integration when PRs are merged to `main`. No manual `supabase db push` is needed.
+
 Ask before any schema, migration, RLS, or non-local data change. Full guidance lives in [docs/supabase-local-dev.md](./docs/supabase-local-dev.md) and [AGENTS.md](./AGENTS.md).
 
 ## Deployment

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -193,6 +193,10 @@ For UI changes:
 
 - Codex automatically reviews every new PR within a few minutes.
 - Review comments appear as threads on the PR diff.
+- **For every Codex comment, take one of these actions:**
+  1. **Push a fix** if the feedback is valid and actionable.
+  2. **Reply with an explanation** if the comment is a false positive, not applicable, or can be safely ignored (e.g. pending migration not yet applied, review against stale base, etc.).
+     Never leave a Codex comment unanswered.
 - After fixing issues, push the changes and trigger a re-review:
   ```
   @codex review

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -78,12 +78,11 @@ When working on schema changes, **use the local Supabase instance by default**:
    ```
 6. Verify the app works against the local instance with `pnpm local:dev`.
 
-You do not need `supabase link` or `supabase db push` for normal migration work. The Supabase GitHub integration handles deployment:
+You do not need `supabase link` or `supabase db push` for normal migration work. We are on the Supabase free tier — there is no database branching. The deploy preview shares the production database, and migrations only apply to production when the PR is merged to `main` via Supabase GitHub integration.
 
-- Migrations auto-apply to the **PR preview branch** on push.
-- Migrations auto-apply to **production** when the PR is merged to `main`.
+Features depending on pending migrations may not work in the Netlify preview. That is expected. Test migrations locally (`pnpm db:reset`) as the primary verification step. If you need the preview to work before merge, manually apply migrations with `pnpm supabase:link:prod && pnpm db:push:remote` and unlink after.
 
-**Do not run `pnpm db:push:remote`** unless the user explicitly asks and the GitHub integration is unavailable.
+**Do not run `pnpm db:push:remote`** unless the user explicitly asks.
 
 For full details, see [`docs/supabase-local-dev.md`](./docs/supabase-local-dev.md).
 
@@ -95,7 +94,7 @@ The local database is seeded automatically by `pnpm db:reset` from `supabase/see
 
 For local UI testing, mutation-based setup, and proofing, it is expected that you edit the local database freely. The local stack is disposable.
 
-For UI testing on Netlify deploy previews, demo data must be inserted directly into the **preview branch** database (not production) so the preview shows real content:
+For UI testing on Netlify deploy previews, demo data must be inserted directly into the production database since the preview shares it:
 
 ```bash
 # Use MCP execute_sql or Supabase dashboard
@@ -179,11 +178,12 @@ For UI changes:
 - **Test the preview on mobile** — the deploy preview is the closest thing to production.
 - For UI PRs, do not rely on Netlify alone. Local proof screenshots published from `proof:publish` are also required.
 
-### Supabase Preview Branch
+### Supabase Database
 
-- Supabase Git integration creates a preview branch for the PR.
-- Migrations from `supabase/migrations/` are auto-applied.
-- The deploy preview connects to this preview database, **not** production.
+- The project is on Supabase **free tier** — there is no database branching.
+- The Netlify deploy preview shares the **same production Supabase database**.
+- Migrations from `supabase/migrations/` are only applied when the PR is merged to `main` via the Supabase GitHub integration.
+- Features depending on pending migrations may fail in the preview environment. That is expected.
 
 ---
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -78,7 +78,12 @@ When working on schema changes, **use the local Supabase instance by default**:
    ```
 6. Verify the app works against the local instance with `pnpm local:dev`.
 
-**Do not run `pnpm db:push:remote`** unless the user explicitly asks. The Supabase Git integration auto-deploys migrations to the PR preview branch on push.
+You do not need `supabase link` or `supabase db push` for normal migration work. The Supabase GitHub integration handles deployment:
+
+- Migrations auto-apply to the **PR preview branch** on push.
+- Migrations auto-apply to **production** when the PR is merged to `main`.
+
+**Do not run `pnpm db:push:remote`** unless the user explicitly asks and the GitHub integration is unavailable.
 
 For full details, see [`docs/supabase-local-dev.md`](./docs/supabase-local-dev.md).
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -195,8 +195,8 @@ For UI changes:
 - Review comments appear as threads on the PR diff.
 - **For every Codex comment, take one of these actions:**
   1. **Push a fix** if the feedback is valid and actionable.
-  2. **Reply with an explanation** if the comment is a false positive, not applicable, or can be safely ignored (e.g. pending migration not yet applied, review against stale base, etc.).
-     Never leave a Codex comment unanswered.
+  2. **Reply directly in the Codex review thread** with an explanation if the comment is a false positive, not applicable, or can be safely ignored (e.g. pending migration not yet applied, review against stale base, etc.).
+     Never leave a Codex comment unanswered. Do not reply outside the thread or in a new general comment — the reply must be inline in the existing review thread.
 - After fixing issues, push the changes and trigger a re-review:
   ```
   @codex review

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -145,7 +145,7 @@ Keep commits focused. Use [Conventional Commits](https://www.conventionalcommits
 
 ## 8. Open a Pull Request
 
-Use the GitHub CLI (`gh`) or the web UI.
+Use the GitHub CLI (`gh`) or the web UI. Always include a description before opening — Codex only reviews ready PRs with a body.
 
 ```bash
 gh pr create --title "feat: team management CRUD (#16)" --body "..."
@@ -160,7 +160,7 @@ Closes #16
 If later pushes introduce larger new behavior, migrations, workflow changes, or other meaningful scope changes, update the PR description so it still matches the actual contents of the branch.
 Small follow-up fixes do not need a PR description update unless they materially change scope or rollout considerations.
 
-For UI changes:
+Open PRs as **ready** (not draft) so Codex can review them. The only exception is UI changes:
 
 1. Open the PR as a draft first.
 2. Publish local proof screenshots to the PR.
@@ -191,7 +191,7 @@ For UI changes:
 
 ### Codex (AI Review)
 
-- Codex automatically reviews every new PR within a few minutes.
+- Codex automatically reviews every new PR within a few minutes. **PR must be ready (not draft)** for Codex to pick it up.
 - Review comments appear as threads on the PR diff.
 - **For every Codex comment, take one of these actions:**
   1. **Push a fix** if the feedback is valid and actionable.

--- a/docs/supabase-local-dev.md
+++ b/docs/supabase-local-dev.md
@@ -115,12 +115,26 @@ The Supabase CLI is **not linked to production** during normal development. All 
 
 **How migrations reach production:**
 
-1. You write and test migrations locally (`pnpm db:reset`, `pnpm db-types`).
-2. You commit the migration files and open a PR.
-3. Supabase GitHub integration auto-creates a preview branch for the PR and applies the migrations there.
-4. When the PR is merged to `main`, Supabase GitHub integration auto-applies the migrations to the production database.
+We are on the Supabase **free tier**, which does not include database branching. This means:
 
-You never need to `supabase link` or `supabase db push` for normal migration work.
+1. You write and test migrations locally against the local Supabase instance (`pnpm db:reset`, `pnpm db-types`). Your local schema must mirror production so tests are accurate.
+2. You commit the migration files and open a PR.
+3. The Netlify deploy preview runs against the **same production Supabase database** — there is no preview branch database. If your PR introduces a new migration, features depending on it may fail in the preview environment until the migration is applied.
+4. When the PR is merged to `main`, Supabase GitHub integration auto-applies the migrations to the production database. The deploy preview will then work correctly.
+
+You never need to `supabase link` or `supabase db push` for normal migration work. The GitHub integration handles the single deploy automatically on merge.
+
+**Testing migrations in the preview environment (optional):**
+
+If a new feature requires schema changes and you want the Netlify preview to work before merge, you can manually apply the migration to production:
+
+```bash
+supabase link --project-ref eucjxbcicejyinubzgwh
+pnpm db:push:remote
+supabase unlink
+```
+
+Only do this when you are confident the migration is correct and reversible. Prefer local testing (`pnpm db:reset`) as the primary verification step.
 
 **Temporarily connecting to production for debugging:**
 

--- a/docs/supabase-local-dev.md
+++ b/docs/supabase-local-dev.md
@@ -54,6 +54,21 @@ Do not use `local:hosted` for:
 - `pnpm proof:capture`
 - `pnpm proof:publish`
 
+## Identity Model
+
+The project separates identity into three layers:
+
+| Layer    | Table        | Purpose                                                                   |
+| -------- | ------------ | ------------------------------------------------------------------------- |
+| Auth     | `auth.users` | Supabase Auth — source of truth for email, password, sessions             |
+| Account  | `profiles`   | Account metadata — `is_admin` flag                                        |
+| Gameplay | `players`    | Game identity — public display name, linked to `auth.users` via `user_id` |
+
+- Every new `auth.users` row automatically creates a `profiles` row and a `players` row (via `insert_profile_on_user_creation` trigger).
+- `profiles.user_id` is the primary key, referencing `auth.users(id) ON DELETE CASCADE`.
+- `players.user_id` is nullable — `NULL` for guest/anonymous players.
+- Use `SELECT public.current_player_id()` in RLS policies to resolve `auth.uid()` → `players.id`.
+
 ## Local Auth Users
 
 Seed local auth users with:
@@ -94,6 +109,37 @@ There are two separate saved browser sessions:
 
 If you need the hosted flow, `pnpm auth:hosted` behaves the same as `pnpm auth:prod`.
 
+## CLI Link State — Local by Default
+
+The Supabase CLI is **not linked to production** during normal development. All migration work, testing, and type generation happen against the local Supabase instance.
+
+**How migrations reach production:**
+
+1. You write and test migrations locally (`pnpm db:reset`, `pnpm db-types`).
+2. You commit the migration files and open a PR.
+3. Supabase GitHub integration auto-creates a preview branch for the PR and applies the migrations there.
+4. When the PR is merged to `main`, Supabase GitHub integration auto-applies the migrations to the production database.
+
+You never need to `supabase link` or `supabase db push` for normal migration work.
+
+**Temporarily connecting to production for debugging:**
+
+```bash
+# Link to production (stored in supabase/.temp/, gitignored)
+supabase link --project-ref eucjxbcicejyinubzgwh
+
+# Run read-only queries against production
+supabase db dump --linked --schema public --data-only > /tmp/prod-dump.sql
+psql "$(supabase status -o env | grep ^SUPABASE_DB_URL | cut -d= -f2 | tr -d '"')" -c "SELECT ..."
+
+# When done, go back to local-only
+supabase unlink
+```
+
+The link state is stored in `supabase/.temp/` which is gitignored, so each developer controls their own link state independently.
+
+Never leave the CLI linked to production as the default. Always `supabase unlink` after debugging.
+
 ## Migration Workflow
 
 1. Ask before any schema change, migration, RLS change, or non-local data mutation.
@@ -115,6 +161,7 @@ If you need the hosted flow, `pnpm auth:hosted` behaves the same as `pnpm auth:p
    ```bash
    pnpm local:dev
    ```
+7. Commit the migration files. The Supabase GitHub integration handles deploying to the PR preview branch and, on merge to main, to production automatically.
 
 ## Database Types
 
@@ -124,15 +171,11 @@ pnpm db-types
 
 This regenerates `src/types/database.ts` from the local schema.
 
-## Remote Pushes
+## Manual Remote Pushes (emergency only)
 
-Do not run this unless the user explicitly asks:
+You should never need `supabase db push`. The Supabase GitHub integration auto-deploys migrations when PRs are merged to `main`.
 
-```bash
-pnpm db:push:remote
-```
-
-Normal PR work should rely on migrations plus the Supabase preview branch workflow.
+Only run `pnpm db:push:remote` if the user explicitly asks and the GitHub integration is broken or unavailable. This requires the CLI to be linked to production first.
 
 ## Security Rules
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "proof:capture": "node scripts/screenshot-auth.mjs",
     "proof:publish": "node scripts/proof-publish.mjs",
     "db:push:remote": "supabase db push",
+    "supabase:link:prod": "supabase link --project-ref eucjxbcicejyinubzgwh",
+    "supabase:unlink": "supabase unlink",
     "test:e2e": "playwright test e2e/anonymous-smoke.spec.ts",
     "test:e2e:auth": "playwright test e2e/auth-integration.spec.ts",
     "test:e2e:all": "playwright test",

--- a/scripts/seed-local-auth.ts
+++ b/scripts/seed-local-auth.ts
@@ -101,21 +101,27 @@ for (const user of users) {
     console.log(`  ${user.email} — created (id: ${data.user.id}).`);
     created++;
 
-    const { error: profileError } = await supabase.from("profiles").upsert(
-      {
-        user_id: data.user.id,
-        is_admin: user.is_admin,
-        first_name: user.first_name,
-        last_name: user.last_name,
-        email: user.email,
-      },
-      { onConflict: "user_id" }
-    );
+    const { error: profileError } = await supabase
+      .from("profiles")
+      .update({ is_admin: user.is_admin })
+      .eq("user_id", data.user.id);
 
     if (profileError) {
-      console.error(`  ${user.email} — profile upsert error:`, profileError.message);
+      console.error(`  ${user.email} — profile update error:`, profileError.message);
     } else {
-      console.log(`  ${user.email} — profile upserted.`);
+      console.log(`  ${user.email} — profile updated (admin: ${user.is_admin}).`);
+    }
+
+    const displayName = `${user.first_name} ${user.last_name}`;
+    const { error: playerError } = await supabase
+      .from("players")
+      .update({ name: displayName })
+      .eq("user_id", data.user.id);
+
+    if (playerError) {
+      console.error(`  ${user.email} — player update error:`, playerError.message);
+    } else {
+      console.log(`  ${user.email} — player updated (name: ${displayName}).`);
     }
   }
 }

--- a/src/service/teamService.ts
+++ b/src/service/teamService.ts
@@ -77,33 +77,18 @@ export const getTeamsByIds = async (teamIds: number[]): Promise<Tables<"teams">[
 
 export const createTeam = async (params: CreateTeamParams) => {
   const client = requireSupabase();
-  const { data, error: teamError } = await client
-    .from("teams")
-    .insert({
-      name: params.name,
-      type: "team",
-    })
-    .select()
-    .single();
 
-  if (teamError) {
-    console.error("Error creating team: ", teamError);
-    throw new Error(teamError.message);
+  const { data, error } = await client.rpc("create_team_with_members", {
+    p_name: params.name,
+    p_player_ids: params.playerIds,
+  });
+
+  if (error) {
+    console.error("Error creating team:", error);
+    throw new Error(error.message);
   }
 
-  const teamMembers = params.playerIds.map((player_id) => ({
-    player_id,
-    team_id: data.id,
-  }));
-
-  const { error: memberError } = await client.from("team_members").insert(teamMembers);
-
-  if (memberError) {
-    console.error("Error adding team members", memberError);
-    throw new Error(memberError.message);
-  }
-
-  return data;
+  return { id: data, name: params.name };
 };
 
 export const updateTeam = async (teamId: number, params: CreateTeamParams) => {
@@ -126,17 +111,13 @@ export const updateTeam = async (teamId: number, params: CreateTeamParams) => {
 
 export const deleteTeam = async (teamId: number) => {
   const client = requireSupabase();
-  const { error: memberError } = await client.from("team_members").delete().eq("team_id", teamId);
 
-  if (memberError) {
-    console.error("Error deleting team members:", memberError);
-    throw new Error(memberError.message);
-  }
+  const { error } = await client.rpc("delete_team", {
+    target_team_id: teamId,
+  });
 
-  const { error: teamError } = await client.from("teams").delete().eq("id", teamId);
-
-  if (teamError) {
-    console.log("Error deleting team:", teamError);
-    throw new Error(teamError.message);
+  if (error) {
+    console.error("Error deleting team:", error);
+    throw new Error(error.message);
   }
 };

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -176,46 +176,40 @@ export type Database = {
           created_at: string;
           id: number;
           name: string;
+          user_id: string | null;
         };
         Insert: {
           created_at?: string;
           id?: number;
           name: string;
+          user_id?: string | null;
         };
         Update: {
           created_at?: string;
           id?: number;
           name?: string;
+          user_id?: string | null;
         };
         Relationships: [];
       };
       profiles: {
         Row: {
           created_at: string;
-          email: string | null;
-          first_name: string | null;
-          id: number;
           is_admin: boolean;
-          last_name: string | null;
-          user_id: string | null;
+          updated_at: string;
+          user_id: string;
         };
         Insert: {
           created_at?: string;
-          email?: string | null;
-          first_name?: string | null;
-          id?: number;
           is_admin?: boolean;
-          last_name?: string | null;
-          user_id?: string | null;
+          updated_at?: string;
+          user_id: string;
         };
         Update: {
           created_at?: string;
-          email?: string | null;
-          first_name?: string | null;
-          id?: number;
           is_admin?: boolean;
-          last_name?: string | null;
-          user_id?: string | null;
+          updated_at?: string;
+          user_id?: string;
         };
         Relationships: [];
       };
@@ -286,6 +280,7 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
+      current_player_id: { Args: never; Returns: number };
       delete_player_with_linked_team: {
         Args: { target_player_id: number };
         Returns: undefined;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -297,6 +297,7 @@ export type Database = {
         Returns: number;
       };
       is_admin: { Args: never; Returns: boolean };
+      is_match_participant: { Args: { p_match_id: number }; Returns: boolean };
       record_goal_event: {
         Args: {
           p_dedupe_key?: string;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -280,11 +280,16 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
+      create_team_with_members: {
+        Args: { p_name: string; p_player_ids: number[] };
+        Returns: number;
+      };
       current_player_id: { Args: never; Returns: number };
       delete_player_with_linked_team: {
         Args: { target_player_id: number };
         Returns: undefined;
       };
+      delete_team: { Args: { target_team_id: number }; Returns: undefined };
       get_match_score: {
         Args: { p_match_id: number };
         Returns: {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,5 +1,13 @@
 # For detailed configuration reference documentation, visit:
 # https://supabase.com/docs/guides/local-development/cli/config
+#
+# LOCAL-FIRST: This config describes the local Supabase development instance.
+# All migration work, type generation, and testing happen locally by default.
+# Migrations reach production automatically via Supabase GitHub integration when
+# PRs are merged to main — no manual `supabase db push` needed.
+# Do not leave the CLI linked to production. For temporary prod debugging, use
+# `supabase link --project-ref eucjxbcicejyinubzgwh`, then `supabase unlink` after.
+#
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
 project_id = "foosball-tracker"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -3,8 +3,8 @@
 #
 # LOCAL-FIRST: This config describes the local Supabase development instance.
 # All migration work, type generation, and testing happen locally by default.
-# Migrations reach production automatically via Supabase GitHub integration when
-# PRs are merged to main — no manual `supabase db push` needed.
+# The project is on Supabase free tier — no database branching. Migrations are
+# applied to production via Supabase GitHub integration when PRs merge to main.
 # Do not leave the CLI linked to production. For temporary prod debugging, use
 # `supabase link --project-ref eucjxbcicejyinubzgwh`, then `supabase unlink` after.
 #

--- a/supabase/migrations/20260602151255_auth_player_profiles_cleanup.sql
+++ b/supabase/migrations/20260602151255_auth_player_profiles_cleanup.sql
@@ -1,0 +1,154 @@
+-- Migration: Auth-to-player schema and profiles model cleanup
+-- Goal: players as canonical game identity linked to auth.users,
+-- profiles as account metadata only, with trigger creating both.
+-- See: https://github.com/foosball-tracker/foosball-tracker/issues/53
+--
+-- Identity model:
+--   auth.users  — Supabase Auth (source of truth for email)
+--   profiles     — account metadata (is_admin)
+--   players      — gameplay identity (name, user_id link to auth)
+
+-- =====================================================
+-- 1. ADD players.user_id
+-- =====================================================
+
+ALTER TABLE public.players
+  ADD COLUMN user_id uuid UNIQUE REFERENCES auth.users(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.players.user_id IS
+  'Links a gameplay player to an auth account. NULL for guest/anonymous players.';
+
+-- =====================================================
+-- 2. CLEAN UP profiles
+-- =====================================================
+
+DELETE FROM public.profiles WHERE user_id IS NULL;
+
+ALTER TABLE public.profiles DROP CONSTRAINT IF EXISTS profiles_pkey CASCADE;
+ALTER TABLE public.profiles DROP CONSTRAINT IF EXISTS profiles_email_key;
+ALTER TABLE public.profiles DROP CONSTRAINT IF EXISTS profiles_user_id_key;
+ALTER TABLE public.profiles DROP CONSTRAINT IF EXISTS profiles_user_id_fkey;
+
+ALTER TABLE public.profiles DROP COLUMN IF EXISTS id;
+ALTER TABLE public.profiles DROP COLUMN IF EXISTS email;
+ALTER TABLE public.profiles DROP COLUMN IF EXISTS first_name;
+ALTER TABLE public.profiles DROP COLUMN IF EXISTS last_name;
+
+ALTER TABLE public.profiles ADD PRIMARY KEY (user_id);
+
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_user_id_fkey
+  FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+COMMENT ON TABLE public.profiles IS 'Account metadata for authenticated users. One row per auth user.';
+
+-- =====================================================
+-- 3. UPDATE AUTH TRIGGER
+-- Replace the trigger function to create both a profile
+-- and a player for every new auth user.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.insert_profile_on_user_creation()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  player_name text;
+BEGIN
+  INSERT INTO public.profiles (user_id, is_admin)
+  VALUES (NEW.id, false);
+
+  player_name := COALESCE(
+    NEW.raw_user_meta_data->>'name',
+    NEW.email
+  );
+
+  INSERT INTO public.players (name, user_id)
+  VALUES (player_name, NEW.id);
+
+  RETURN NEW;
+END;
+$$;
+
+-- =====================================================
+-- 4. current_player_id() HELPER
+-- Resolves auth.uid() → players.id for RLS policies.
+-- Returns NULL if the authenticated user has no linked player.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.current_player_id()
+RETURNS bigint
+LANGUAGE plpgsql
+STABLE
+SECURITY INVOKER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_player_id bigint;
+BEGIN
+  SELECT id INTO v_player_id
+  FROM public.players
+  WHERE user_id = auth.uid()
+  LIMIT 1;
+  RETURN v_player_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.current_player_id IS
+  'Returns the player id for the current authenticated user, or NULL if not linked. Use in RLS policies to identify match participants.';
+
+GRANT EXECUTE ON FUNCTION public.current_player_id() TO authenticated, anon;
+
+-- =====================================================
+-- 5. UPDATE RLS POLICIES
+-- =====================================================
+
+-- 5a. Players: replace wide-open policy with scoped policies.
+--     Authenticated users can view and create players (needed for
+--     match setup, player lists, leaderboard, guest players).
+--     Only the linked user or admin can modify their own player row.
+DROP POLICY IF EXISTS "Enables full access for authenticated Users" ON public.players;
+
+CREATE POLICY "Authenticated users can view all players" ON public.players
+  FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY "Authenticated users can create players" ON public.players
+  FOR INSERT TO authenticated WITH CHECK (true);
+
+CREATE POLICY "Users can update own player" ON public.players
+  FOR UPDATE TO authenticated
+  USING (public.is_admin() OR user_id = (SELECT auth.uid()))
+  WITH CHECK (public.is_admin() OR user_id = (SELECT auth.uid()));
+
+CREATE POLICY "Users can delete own player" ON public.players
+  FOR DELETE TO authenticated
+  USING (public.is_admin() OR user_id = (SELECT auth.uid()));
+
+-- 5b. Profiles: add SELECT and UPDATE policies.
+--     INSERT is handled by the SECURITY DEFINER trigger.
+DROP POLICY IF EXISTS "Users can insert their own profile" ON public.profiles;
+
+CREATE POLICY "Users can view own profile" ON public.profiles
+  FOR SELECT TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "Users can update own profile" ON public.profiles
+  FOR UPDATE TO authenticated
+  USING (user_id = (SELECT auth.uid()))
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "Admin can manage all profiles" ON public.profiles
+  FOR ALL TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- =====================================================
+-- NOTES: Match, goal, and match_event policies remain as-is
+-- for now (authenticated users can track active matches).
+-- The new players.user_id column and current_player_id() RPC
+-- enable future participant-aware tightening.
+-- =====================================================

--- a/supabase/migrations/20260602180000_match_goal_participant_rls.sql
+++ b/supabase/migrations/20260602180000_match_goal_participant_rls.sql
@@ -1,0 +1,176 @@
+-- Migration: Participant-aware match/goal/event RLS
+-- Tightens policies so only participants + admins can mutate
+-- matches, goals, and match_events.
+-- Depends on players.user_id and current_player_id() from
+-- 20260602151255_auth_player_profiles_cleanup.sql.
+-- See: https://github.com/foosball-tracker/foosball-tracker/issues/35
+
+-- =====================================================
+-- 1. is_match_participant() HELPER
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.is_match_participant(p_match_id bigint)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY INVOKER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_player_id bigint;
+  v_home_team_id bigint;
+  v_away_team_id bigint;
+BEGIN
+  v_player_id := public.current_player_id();
+  IF v_player_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  SELECT home_team_id, away_team_id INTO v_home_team_id, v_away_team_id
+  FROM public.matches
+  WHERE id = p_match_id;
+
+  IF v_home_team_id IS NOT NULL THEN
+    IF EXISTS (
+      SELECT 1 FROM public.teams
+      WHERE id = v_home_team_id AND player_id = v_player_id
+    ) THEN
+      RETURN true;
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM public.team_members
+      WHERE team_id = v_home_team_id AND player_id = v_player_id
+    ) THEN
+      RETURN true;
+    END IF;
+  END IF;
+
+  IF v_away_team_id IS NOT NULL THEN
+    IF EXISTS (
+      SELECT 1 FROM public.teams
+      WHERE id = v_away_team_id AND player_id = v_player_id
+    ) THEN
+      RETURN true;
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM public.team_members
+      WHERE team_id = v_away_team_id AND player_id = v_player_id
+    ) THEN
+      RETURN true;
+    END IF;
+  END IF;
+
+  RETURN false;
+END;
+$$;
+
+COMMENT ON FUNCTION public.is_match_participant IS
+  'Returns true if the current authenticated user is linked to a player on either team of the given match. Used in RLS policies for participant-aware access control.';
+
+GRANT EXECUTE ON FUNCTION public.is_match_participant TO authenticated, anon;
+
+-- =====================================================
+-- 2. MATCHES — participant-aware mutations
+-- =====================================================
+
+-- 2a. INSERT: creator must be on one of the teams (or admin)
+DROP POLICY IF EXISTS "Authenticated users can create matches" ON public.matches;
+CREATE POLICY "Participants can create matches" ON public.matches
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    public.is_admin()
+    OR (
+      public.current_player_id() IS NOT NULL
+      AND (
+        EXISTS (SELECT 1 FROM public.teams WHERE id = home_team_id AND player_id = public.current_player_id())
+        OR EXISTS (SELECT 1 FROM public.team_members WHERE team_id = home_team_id AND player_id = public.current_player_id())
+        OR EXISTS (SELECT 1 FROM public.teams WHERE id = away_team_id AND player_id = public.current_player_id())
+        OR EXISTS (SELECT 1 FROM public.team_members WHERE team_id = away_team_id AND player_id = public.current_player_id())
+      )
+    )
+  );
+
+-- 2b. UPDATE: only participants (+ admins) can finish active matches
+DROP POLICY IF EXISTS "Authenticated users can finish active matches" ON public.matches;
+CREATE POLICY "Participants can finish active matches" ON public.matches
+  FOR UPDATE TO authenticated
+  USING (in_progress = true AND (public.is_admin() OR public.is_match_participant(id)))
+  WITH CHECK (in_progress = false);
+
+-- 2c. DELETE: only participants (+ admins) can abandon active matches
+DROP POLICY IF EXISTS "Authenticated users can abandon active matches" ON public.matches;
+CREATE POLICY "Participants can abandon active matches" ON public.matches
+  FOR DELETE TO authenticated
+  USING (in_progress = true AND (public.is_admin() OR public.is_match_participant(id)));
+
+-- =====================================================
+-- 3. GOALS — participant-aware mutations
+-- =====================================================
+
+-- 3a. INSERT: participants (+ admins) can record goals for active matches
+DROP POLICY IF EXISTS "Authenticated users can record goals for active matches" ON public.goals;
+CREATE POLICY "Participants can record goals for active matches" ON public.goals
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.matches
+      WHERE matches.id = goals.match_id
+        AND matches.in_progress = true
+    )
+    AND (public.is_admin() OR public.is_match_participant(goals.match_id))
+  );
+
+-- 3b. DELETE: participants (+ admins) can remove goals from active matches
+DROP POLICY IF EXISTS "Authenticated users can remove goals from active matches" ON public.goals;
+CREATE POLICY "Participants can remove goals from active matches" ON public.goals
+  FOR DELETE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.matches
+      WHERE matches.id = goals.match_id
+        AND matches.in_progress = true
+    )
+    AND (public.is_admin() OR public.is_match_participant(goals.match_id))
+  );
+
+-- =====================================================
+-- 4. MATCH EVENTS — participant-aware mutations
+-- =====================================================
+
+-- 4a. INSERT: participants (+ admins) can record events for active matches
+DROP POLICY IF EXISTS "Authenticated users can record events for active matches" ON public.match_events;
+CREATE POLICY "Participants can record events for active matches" ON public.match_events
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.matches
+      WHERE matches.id = match_events.match_id
+        AND matches.in_progress = true
+    )
+    AND (public.is_admin() OR public.is_match_participant(match_events.match_id))
+  );
+
+-- 4b. UPDATE: participants (+ admins) can update events for active matches
+DROP POLICY IF EXISTS "Authenticated users can update events for active matches" ON public.match_events;
+CREATE POLICY "Participants can update events for active matches" ON public.match_events
+  FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.matches
+      WHERE matches.id = match_events.match_id
+        AND matches.in_progress = true
+    )
+    AND (public.is_admin() OR public.is_match_participant(match_events.match_id))
+  );
+
+-- 4c. DELETE: participants (+ admins) can delete events from active matches
+CREATE POLICY "Participants can delete events from active matches" ON public.match_events
+  FOR DELETE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.matches
+      WHERE matches.id = match_events.match_id
+        AND matches.in_progress = true
+    )
+    AND (public.is_admin() OR public.is_match_participant(match_events.match_id))
+  );

--- a/supabase/migrations/20260602184051_tighten_team_members_rls.sql
+++ b/supabase/migrations/20260602184051_tighten_team_members_rls.sql
@@ -1,0 +1,161 @@
+-- Migration: Tighten team_members RLS, backfill player-team links
+-- Addresses Codex review comments on PR #55:
+--   P1: team_members full-access RLS bypasses participant check
+--   P2: trigger doesn't create player-type team on signup
+--   P2: no backfill for existing auth users
+-- See: https://github.com/foosball-tracker/foosball-tracker/issues/35
+
+-- =====================================================
+-- 1. TIGHTEN team_members RLS
+--    Close the hole where any authenticated user can
+--    insert themselves into an active match's team and
+--    then pass is_match_participant().
+-- =====================================================
+
+DROP POLICY IF EXISTS "Enables full access for authenticated Users" ON public.team_members;
+
+CREATE POLICY "Users can join teams" ON public.team_members
+  FOR INSERT TO authenticated
+  WITH CHECK (player_id = public.current_player_id());
+
+CREATE POLICY "Users can leave teams" ON public.team_members
+  FOR DELETE TO authenticated
+  USING (player_id = public.current_player_id());
+
+CREATE POLICY "Users can view team members" ON public.team_members
+  FOR SELECT TO authenticated
+  USING (true);
+
+CREATE POLICY "Admin can manage all team memberships" ON public.team_members
+  FOR ALL TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- =====================================================
+-- 2. UPDATE TRIGGER: also create player-type team
+--    Auth-created players need a matching team row so
+--    they can be used in match setup and satisfy the
+--    participant-aware match RLS.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.insert_profile_on_user_creation()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  player_name text;
+  v_player_id bigint;
+BEGIN
+  INSERT INTO public.profiles (user_id, is_admin)
+  VALUES (NEW.id, false);
+
+  player_name := COALESCE(
+    NEW.raw_user_meta_data->>'name',
+    NEW.email
+  );
+
+  INSERT INTO public.players (name, user_id)
+  VALUES (player_name, NEW.id)
+  RETURNING id INTO v_player_id;
+
+  INSERT INTO public.teams (name, type, player_id)
+  VALUES (player_name, 'player', v_player_id);
+
+  RETURN NEW;
+END;
+$$;
+
+-- =====================================================
+-- 3. UPDATE team-management RPCs for tightened RLS
+--    These run as SECURITY DEFINER so they can manage
+--    other users' memberships without being blocked by
+--    the new "only own player_id" RLS.
+-- =====================================================
+
+-- 3a. update_team_with_members: needs to bypass team_members RLS
+CREATE OR REPLACE FUNCTION public.update_team_with_members(
+    target_team_id bigint,
+    target_name text,
+    target_player_ids bigint[]
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+BEGIN
+  UPDATE public.teams
+  SET name = target_name
+  WHERE id = target_team_id
+    AND type = 'team';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Editable team % not found', target_team_id;
+  END IF;
+
+  DELETE FROM public.team_members
+  WHERE team_id = target_team_id;
+
+  IF coalesce(array_length(target_player_ids, 1), 0) > 0 THEN
+    INSERT INTO public.team_members (player_id, team_id)
+    SELECT player_id, target_team_id
+    FROM unnest(target_player_ids) AS player_id;
+  END IF;
+END;
+$$;
+
+-- 3b. delete_player_with_linked_team: needs to bypass players RLS
+CREATE OR REPLACE FUNCTION public.delete_player_with_linked_team(target_player_id bigint)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+BEGIN
+  DELETE FROM public.teams
+  WHERE player_id = target_player_id
+    AND type = 'player';
+
+  DELETE FROM public.players
+  WHERE id = target_player_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Player % not found', target_player_id;
+  END IF;
+END;
+$$;
+
+-- =====================================================
+-- 4. BACKFILL existing auth users
+--    Link auth users who don't yet have a player to a
+--    new player row + matching player-type team so they
+--    are not locked out of match participation.
+-- =====================================================
+
+DO $$
+DECLARE
+  u RECORD;
+  v_player_id bigint;
+  v_player_name text;
+BEGIN
+  FOR u IN
+    SELECT id, email, raw_user_meta_data
+    FROM auth.users
+    WHERE id NOT IN (
+      SELECT user_id FROM public.players WHERE user_id IS NOT NULL
+    )
+  LOOP
+    v_player_name := COALESCE(u.raw_user_meta_data->>'name', u.email);
+
+    INSERT INTO public.players (name, user_id)
+    VALUES (v_player_name, u.id)
+    RETURNING id INTO v_player_id;
+
+    INSERT INTO public.teams (name, type, player_id)
+    VALUES (v_player_name, 'player', v_player_id)
+    ON CONFLICT DO NOTHING;
+  END LOOP;
+END;
+$$;

--- a/supabase/migrations/20260602191621_close_remaining_rls_bypasses.sql
+++ b/supabase/migrations/20260602191621_close_remaining_rls_bypasses.sql
@@ -1,0 +1,114 @@
+-- Migration: Close remaining participant-check bypass vectors
+-- Addresses Codex P1 review comments on PR #55:
+--   - Prevent self-joins to teams in active matches
+--   - Add authorization to update_team_with_members RPC
+--   - Add authorization to delete_player_with_linked_team RPC
+-- See: https://github.com/foosball-tracker/foosball-tracker/issues/35
+
+-- =====================================================
+-- 1. BLOCK self-joins to teams in active matches
+--    A user could still INSERT their own player_id into
+--    a team that is currently in an active match, then
+--    pass is_match_participant(). Prevent that.
+-- =====================================================
+
+DROP POLICY IF EXISTS "Users can join teams" ON public.team_members;
+
+CREATE POLICY "Users can join teams" ON public.team_members
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    player_id = public.current_player_id()
+    AND NOT EXISTS (
+      SELECT 1 FROM public.matches
+      WHERE (home_team_id = team_id OR away_team_id = team_id)
+        AND in_progress = true
+    )
+  );
+
+-- =====================================================
+-- 2. AUTHORIZE update_team_with_members RPC
+--    Now runs as SECURITY DEFINER but had no permission
+--    check — any authenticated caller could replace the
+--    members of any custom team. Require team membership
+--    or admin.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.update_team_with_members(
+    target_team_id bigint,
+    target_name text,
+    target_player_ids bigint[]
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_player_id bigint;
+BEGIN
+  v_player_id := public.current_player_id();
+
+  IF NOT public.is_admin() AND (
+    v_player_id IS NULL
+    OR NOT EXISTS (
+      SELECT 1 FROM public.team_members
+      WHERE team_id = target_team_id AND player_id = v_player_id
+    )
+  ) THEN
+    RAISE EXCEPTION 'You must be a member of team % to edit it', target_team_id;
+  END IF;
+
+  UPDATE public.teams
+  SET name = target_name
+  WHERE id = target_team_id
+    AND type = 'team';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Editable team % not found', target_team_id;
+  END IF;
+
+  DELETE FROM public.team_members
+  WHERE team_id = target_team_id;
+
+  IF coalesce(array_length(target_player_ids, 1), 0) > 0 THEN
+    INSERT INTO public.team_members (player_id, team_id)
+    SELECT player_id, target_team_id
+    FROM unnest(target_player_ids) AS player_id;
+  END IF;
+END;
+$$;
+
+-- =====================================================
+-- 3. AUTHORIZE delete_player_with_linked_team RPC
+--    Now runs as SECURITY DEFINER but had no permission
+--    check — any caller could delete any player. Require
+--    player ownership or admin.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.delete_player_with_linked_team(target_player_id bigint)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_player_id bigint;
+BEGIN
+  v_player_id := public.current_player_id();
+
+  IF NOT public.is_admin() AND target_player_id != v_player_id THEN
+    RAISE EXCEPTION 'You can only delete your own player';
+  END IF;
+
+  DELETE FROM public.teams
+  WHERE player_id = target_player_id
+    AND type = 'player';
+
+  DELETE FROM public.players
+  WHERE id = target_player_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Player % not found', target_player_id;
+  END IF;
+END;
+$$;

--- a/supabase/migrations/20260602192713_team_management_rpcs.sql
+++ b/supabase/migrations/20260602192713_team_management_rpcs.sql
@@ -1,0 +1,181 @@
+-- Migration: Fix NULL comparison + add team management RPCs
+-- Addresses Codex review comments on PR #55:
+--   P1: NULL player ownership bypass in delete_player_with_linked_team
+--   P2: createTeam/deleteTeam broken by tightened team_members RLS
+-- See: https://github.com/foosball-tracker/foosball-tracker/issues/35
+
+-- =====================================================
+-- 1. FIX NULL comparison in delete_player_with_linked_team
+--    In PL/pgSQL, "target_player_id != v_player_id" when
+--    v_player_id IS NULL evaluates to NULL (not TRUE), so
+--    the IF condition silently passes. Use IS DISTINCT FROM.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.delete_player_with_linked_team(target_player_id bigint)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_player_id bigint;
+BEGIN
+  v_player_id := public.current_player_id();
+
+  IF NOT public.is_admin() AND target_player_id IS DISTINCT FROM v_player_id THEN
+    RAISE EXCEPTION 'You can only delete your own player';
+  END IF;
+
+  DELETE FROM public.teams
+  WHERE player_id = target_player_id
+    AND type = 'player';
+
+  DELETE FROM public.players
+  WHERE id = target_player_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Player % not found', target_player_id;
+  END IF;
+END;
+$$;
+
+-- =====================================================
+-- 2. CREATE team-with-members RPC
+--    createTeam() in the frontend directly inserted
+--    team_members rows, which is blocked by the new
+--    "only own player_id" RLS. Route through this
+--    SECURITY DEFINER RPC instead.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.create_team_with_members(
+  p_name text,
+  p_player_ids bigint[]
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_team_id bigint;
+BEGIN
+  INSERT INTO public.teams (name, type)
+  VALUES (p_name, 'team')
+  RETURNING id INTO v_team_id;
+
+  IF coalesce(array_length(p_player_ids, 1), 0) > 0 THEN
+    INSERT INTO public.team_members (player_id, team_id)
+    SELECT player_id, v_team_id
+    FROM unnest(p_player_ids) AS player_id;
+  END IF;
+
+  RETURN v_team_id;
+END;
+$$;
+
+-- =====================================================
+-- 3. HARDEN update_team_with_members: block active-match edits
+--    The RPC is SECURITY DEFINER so it bypasses the
+--    team_members INSERT policy. Even with auth checks,
+--    a team member could add/remove players during an
+--    active match, which would bypass is_match_participant().
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.update_team_with_members(
+    target_team_id bigint,
+    target_name text,
+    target_player_ids bigint[]
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_player_id bigint;
+BEGIN
+  v_player_id := public.current_player_id();
+
+  IF NOT public.is_admin() AND (
+    v_player_id IS NULL
+    OR NOT EXISTS (
+      SELECT 1 FROM public.team_members
+      WHERE team_id = target_team_id AND player_id = v_player_id
+    )
+  ) THEN
+    RAISE EXCEPTION 'You must be a member of team % to edit it', target_team_id;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.matches
+    WHERE (home_team_id = target_team_id OR away_team_id = target_team_id)
+      AND in_progress = true
+  ) THEN
+    RAISE EXCEPTION 'Cannot modify team % while it is in an active match', target_team_id;
+  END IF;
+
+  UPDATE public.teams
+  SET name = target_name
+  WHERE id = target_team_id
+    AND type = 'team';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Editable team % not found', target_team_id;
+  END IF;
+
+  DELETE FROM public.team_members
+  WHERE team_id = target_team_id;
+
+  IF coalesce(array_length(target_player_ids, 1), 0) > 0 THEN
+    INSERT INTO public.team_members (player_id, team_id)
+    SELECT player_id, target_team_id
+    FROM unnest(target_player_ids) AS player_id;
+  END IF;
+END;
+$$;
+
+-- =====================================================
+-- 4. DELETE team RPC (with active-match guard)
+--    deleteTeam() in the frontend directly deleted
+--    team_members rows, which is now blocked by the
+--    tightened RLS. Route through this SECURITY DEFINER
+--    RPC with member/admin authorization.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.delete_team(target_team_id bigint)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_player_id bigint;
+BEGIN
+  v_player_id := public.current_player_id();
+
+  IF NOT public.is_admin() AND (
+    v_player_id IS NULL
+    OR NOT EXISTS (
+      SELECT 1 FROM public.team_members
+      WHERE team_id = target_team_id AND player_id = v_player_id
+    )
+  ) THEN
+    RAISE EXCEPTION 'You must be a member of team % to delete it', target_team_id;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.matches
+    WHERE (home_team_id = target_team_id OR away_team_id = target_team_id)
+      AND in_progress = true
+  ) THEN
+    RAISE EXCEPTION 'Cannot delete team % while it is in an active match', target_team_id;
+  END IF;
+
+  DELETE FROM public.team_members WHERE team_id = target_team_id;
+  DELETE FROM public.teams WHERE id = target_team_id AND type = 'team';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Team % not found or is not a custom team', target_team_id;
+  END IF;
+END;
+$$;

--- a/supabase/migrations/20260602193600_rpc_auth_grants.sql
+++ b/supabase/migrations/20260602193600_rpc_auth_grants.sql
@@ -1,0 +1,61 @@
+-- Migration: Restrict new SECURITY DEFINER RPCs to authenticated users
+-- Addresses Codex P1: create_team_with_members had no auth check
+-- and was callable by anon (PUBLIC default). Also defense-in-depth
+-- for the other new RPCs that have body-level auth checks.
+-- See: https://github.com/foosball-tracker/foosball-tracker/issues/35
+
+-- =====================================================
+-- 1. ADD auth check to create_team_with_members
+--    This RPC had no auth.uid() guard — anon/PUBLIC
+--    callers could create arbitrary teams and members,
+--    bypassing the tightened team_members RLS.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.create_team_with_members(
+  p_name text,
+  p_player_ids bigint[]
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_team_id bigint;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required to create a team';
+  END IF;
+
+  INSERT INTO public.teams (name, type)
+  VALUES (p_name, 'team')
+  RETURNING id INTO v_team_id;
+
+  IF coalesce(array_length(p_player_ids, 1), 0) > 0 THEN
+    INSERT INTO public.team_members (player_id, team_id)
+    SELECT player_id, v_team_id
+    FROM unnest(p_player_ids) AS player_id;
+  END IF;
+
+  RETURN v_team_id;
+END;
+$$;
+
+-- =====================================================
+-- 2. REVOKE PUBLIC/anon access from all new SECURITY
+--    DEFINER RPCs. Grant only to authenticated.
+--    Functions with body-level auth checks already block
+--    anon, but this is defense-in-depth.
+-- =====================================================
+
+REVOKE ALL ON FUNCTION public.create_team_with_members(text, bigint[]) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.create_team_with_members(text, bigint[]) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.update_team_with_members(bigint, text, bigint[]) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.update_team_with_members(bigint, text, bigint[]) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.delete_player_with_linked_team(bigint) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.delete_player_with_linked_team(bigint) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.delete_team(bigint) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.delete_team(bigint) TO authenticated;

--- a/supabase/migrations/20260602194200_prevent_self_grant_admin.sql
+++ b/supabase/migrations/20260602194200_prevent_self_grant_admin.sql
@@ -1,0 +1,11 @@
+-- Migration: Prevent users from self-granting admin
+-- The profiles UPDATE policy allowed any user to set is_admin = true
+-- on their own row, bypassing all admin-only RLS guards.
+-- See: https://github.com/foosball-tracker/foosball-tracker/issues/35
+
+DROP POLICY IF EXISTS "Users can update own profile" ON public.profiles;
+
+CREATE POLICY "Users can update own profile" ON public.profiles
+  FOR UPDATE TO authenticated
+  USING (user_id = (SELECT auth.uid()))
+  WITH CHECK (user_id = (SELECT auth.uid()) AND is_admin = false);


### PR DESCRIPTION
## What

Adds participant-aware RLS policies for matches, goals, and match_events.

### Issue #53 (already in PR)
- Simplifies profiles table to account metadata only
- Links players to auth.users via `players.user_id`
- Adds `current_player_id()` helper function
- Replaces auth trigger to create both profile and player on signup
- Players/profiles RLS: scoped update/delete to own user or admin

### Issue #35 (new in this PR)
- Adds `is_match_participant()` helper function that checks if the current user's linked player is on either team of a given match
- Matches: INSERT requires creator to be on one of the teams; UPDATE/DELETE only for participants + admins
- Goals: INSERT/DELETE only for participants + admins (active match)
- Match events: INSERT/UPDATE/DELETE only for participants + admins (active match)
- SELECT policies remain open for all authenticated users (needed for leaderboards, match viewing)

### Migration
- `20260602151255_auth_player_profiles_cleanup.sql` — players.user_id, current_player_id(), profiles/players RLS
- `20260602180000_match_goal_participant_rls.sql` — is_match_participant(), participant-aware match/goal/event RLS

## How participant detection works

- `players.user_id` links a gameplay identity to an auth account
- `current_player_id()` resolves `auth.uid()` → `players.id`
- `is_match_participant(match_id)` checks if that player is on either team (single-player via `teams.player_id` or multi-player via `team_members`)
- All mutation policies combine: `is_admin() OR is_match_participant(id)`

Closes #53
Closes #35
