### PR TITLE
feat: prioritize current user in player and team selection (#54)

### DIFF
--- a/src/components/ProtectedApp.tsx
+++ b/src/components/ProtectedApp.tsx
@@ -9,7 +9,8 @@ import type { ISettings } from "../types/Settings.ts";
 import * as matchService from "../service/matchService";
 import { playSound } from "~/service/soundService.ts";
 import { getSupabaseSchemaIssue } from "~/service/supabaseService.ts";
-import { getAllTeams, getTeamsByIds } from "~/service/teamService.ts";
+import { getAllTeams, getTeamIdsForPlayer, getTeamsByIds } from "~/service/teamService.ts";
+import { getCurrentPlayerId } from "~/service/playerService.ts";
 import type { Tables } from "~/types/database.ts";
 import "../App.css";
 
@@ -23,6 +24,15 @@ export default function ProtectedApp() {
     goalsToWin: 6,
   });
   const [availableTeams] = createResource(getAllTeams);
+
+  const loadCurrentPlayerInfo = async () => {
+    const playerId = await getCurrentPlayerId();
+    if (playerId === null) return { playerId: null, teamIds: [] as number[] };
+    const teamIds = await getTeamIdsForPlayer(playerId);
+    return { playerId, teamIds };
+  };
+  const [currentPlayerInfo] = createResource(loadCurrentPlayerInfo);
+
   const [currentMatch, setCurrentMatch] = createSignal<MatchRow | null>(null);
   const [matchEvents, setMatchEvents] = createSignal<MatchEventRow[]>([]);
   const [isPaused, setIsPaused] = createSignal(false);
@@ -136,6 +146,10 @@ export default function ProtectedApp() {
     if (hasSchemaIssue()) return;
     if (!blackTeam.id || !yellowTeam.id) {
       alert("Please select both teams before starting the game.");
+      return;
+    }
+    if (yellowTeam.id === blackTeam.id) {
+      alert("Yellow and Black teams must be different.");
       return;
     }
 
@@ -332,6 +346,8 @@ export default function ProtectedApp() {
             settings={settings}
             setSettings={setSettings}
             teamOptions={availableTeams() ?? []}
+            currentPlayerId={currentPlayerInfo()?.playerId ?? null}
+            currentPlayerTeamIds={currentPlayerInfo()?.teamIds ?? []}
           />
         }
       >

--- a/src/components/home/MatchSetupPanel.tsx
+++ b/src/components/home/MatchSetupPanel.tsx
@@ -86,14 +86,16 @@ export function MatchSetupPanel(props: Readonly<MatchSetupPanelProps>) {
       hasOwnTeams && !yellowIsOwn
         ? availableOptions[0]
         : (optionById(availableOptions, yellowTeam.id) ?? availableOptions[0]);
+
+    const findBlackDefault = () => {
+      const sameAsYellow = availableOptions[1]?.value === yellowOption.value;
+      return availableOptions[sameAsYellow ? 2 : 1] ?? yellowOption;
+    };
+
     const blackOption =
       hasOwnTeams && !blackIsOwn
         ? (availableOptions[1] ?? availableOptions[0])
-        : (optionById(availableOptions, blackTeam.id) ??
-          (availableOptions[1]?.value !== yellowOption.value
-            ? availableOptions[1]
-            : availableOptions[2]) ??
-          yellowOption);
+        : (optionById(availableOptions, blackTeam.id) ?? findBlackDefault());
 
     if (yellowOption.value !== yellowTeam.id || yellowOption.label !== yellowTeam.name) {
       props.setSettings("yellowTeam", { id: yellowOption.value, name: yellowOption.label });

--- a/src/components/home/MatchSetupPanel.tsx
+++ b/src/components/home/MatchSetupPanel.tsx
@@ -80,22 +80,16 @@ export function MatchSetupPanel(props: Readonly<MatchSetupPanelProps>) {
 
     const hasOwnTeams = ownIds.size > 0;
     const yellowIsOwn = yellowTeam.id != null && ownIds.has(yellowTeam.id);
-    const blackIsOwn = blackTeam.id != null && ownIds.has(blackTeam.id);
 
     const yellowOption =
-      hasOwnTeams && !yellowIsOwn
+      hasOwnTeams && (yellowTeam.id == null || !yellowIsOwn)
         ? availableOptions[0]
         : (optionById(availableOptions, yellowTeam.id) ?? availableOptions[0]);
 
-    const findBlackDefault = () => {
-      const sameAsYellow = availableOptions[1]?.value === yellowOption.value;
-      return availableOptions[sameAsYellow ? 2 : 1] ?? yellowOption;
-    };
-
     const blackOption =
-      hasOwnTeams && !blackIsOwn
-        ? (availableOptions[1] ?? availableOptions[0])
-        : (optionById(availableOptions, blackTeam.id) ?? findBlackDefault());
+      optionById(availableOptions, blackTeam.id) ??
+      availableOptions.find((o) => o.value !== yellowOption.value) ??
+      yellowOption;
 
     if (yellowOption.value !== yellowTeam.id || yellowOption.label !== yellowTeam.name) {
       props.setSettings("yellowTeam", { id: yellowOption.value, name: yellowOption.label });

--- a/src/components/home/MatchSetupPanel.tsx
+++ b/src/components/home/MatchSetupPanel.tsx
@@ -71,18 +71,13 @@ export function MatchSetupPanel(props: Readonly<MatchSetupPanelProps>) {
     opts.find((option) => option.value === id);
 
   createEffect(() => {
-    const ownIds = ownTeamIds();
     const availableOptions = options();
     if (!availableOptions.length) return;
 
     const yellowTeam = props.settings.yellowTeam;
     const blackTeam = props.settings.blackTeam;
 
-    const yellowOption =
-      ownIds.size > 0 && yellowTeam.id == null
-        ? availableOptions[0]
-        : (optionById(availableOptions, yellowTeam.id) ?? availableOptions[0]);
-
+    const yellowOption = optionById(availableOptions, yellowTeam.id) ?? availableOptions[0];
     const blackOption =
       optionById(availableOptions, blackTeam.id) ??
       availableOptions.find((o) => o.value !== yellowOption.value) ??

--- a/src/components/home/MatchSetupPanel.tsx
+++ b/src/components/home/MatchSetupPanel.tsx
@@ -39,7 +39,7 @@ export function MatchSetupPanel(props: Readonly<MatchSetupPanelProps>) {
       .map((team) => {
         const isOwn = ownIds.has(team.id);
         const label = team.type === "player" ? `${team.name} (Player)` : `${team.name} (Team)`;
-        return { value: team.id, label: isOwn ? `${team.name} (You)` : label };
+        return { value: team.id, label: isOwn ? `${team.name} (You)` : label, highlighted: isOwn };
       });
   };
 

--- a/src/components/home/MatchSetupPanel.tsx
+++ b/src/components/home/MatchSetupPanel.tsx
@@ -1,4 +1,4 @@
-import { createEffect } from "solid-js";
+import { createEffect, createMemo } from "solid-js";
 import type { SetStoreFunction } from "solid-js/store";
 import { CirclePlay, Goal, Shield } from "lucide-solid";
 import Select from "~/components/shared/Select.tsx";
@@ -11,13 +11,51 @@ interface MatchSetupPanelProps {
   settings: ISettings;
   setSettings: SetStoreFunction<ISettings>;
   teamOptions: Tables<"teams">[];
+  currentPlayerId: number | null;
+  currentPlayerTeamIds: number[];
 }
 
 export function MatchSetupPanel(props: Readonly<MatchSetupPanelProps>) {
-  const options = () =>
-    props.teamOptions.map((team) => ({
-      value: team.id,
-      label: team.type === "player" ? `${team.name} (Player)` : `${team.name} (Team)`,
+  const ownTeamIds = createMemo(() => {
+    const ids = new Set(props.currentPlayerTeamIds);
+    for (const team of props.teamOptions) {
+      if (team.type === "player" && team.player_id === props.currentPlayerId) {
+        ids.add(team.id);
+      }
+    }
+    return ids;
+  });
+
+  const options = () => {
+    const ownIds = ownTeamIds();
+    return [...props.teamOptions]
+      .sort((a, b) => {
+        const aOwn = ownIds.has(a.id);
+        const bOwn = ownIds.has(b.id);
+        if (aOwn && !bOwn) return -1;
+        if (!aOwn && bOwn) return 1;
+        return 0;
+      })
+      .map((team) => {
+        const isOwn = ownIds.has(team.id);
+        const label = team.type === "player" ? `${team.name} (Player)` : `${team.name} (Team)`;
+        return { value: team.id, label: isOwn ? `${team.name} (You)` : label };
+      });
+  };
+
+  const yellowTeamId = () => props.settings.yellowTeam.id;
+  const blackTeamId = () => props.settings.blackTeam.id;
+
+  const yellowOptions = () =>
+    options().map((opt) => ({
+      ...opt,
+      disabled: opt.value === blackTeamId(),
+    }));
+
+  const blackOptions = () =>
+    options().map((opt) => ({
+      ...opt,
+      disabled: opt.value === yellowTeamId(),
     }));
 
   const selectedName = (name: string) => name || "Select team";
@@ -26,17 +64,22 @@ export function MatchSetupPanel(props: Readonly<MatchSetupPanelProps>) {
       props.backendReady &&
       props.settings.yellowTeam.id &&
       props.settings.blackTeam.id &&
+      props.settings.yellowTeam.id !== props.settings.blackTeam.id &&
       options().length
     );
-  const optionById = (id: number | undefined) => options().find((option) => option.value === id);
+  const optionById = (opts: { value: number; label: string }[], id: number | undefined) =>
+    opts.find((option) => option.value === id);
 
   createEffect(() => {
     const availableOptions = options();
     if (!availableOptions.length) return;
 
-    const yellowOption = optionById(props.settings.yellowTeam.id) ?? availableOptions[0];
+    const yellowOption =
+      optionById(availableOptions, props.settings.yellowTeam.id) ?? availableOptions[0];
     const blackOption =
-      optionById(props.settings.blackTeam.id) ?? availableOptions[1] ?? yellowOption;
+      optionById(availableOptions, props.settings.blackTeam.id) ??
+      availableOptions[1] ??
+      yellowOption;
 
     if (
       yellowOption.value !== props.settings.yellowTeam.id ||
@@ -87,7 +130,7 @@ export function MatchSetupPanel(props: Readonly<MatchSetupPanelProps>) {
                 onChange={(value, option) =>
                   props.setSettings("yellowTeam", { id: value, name: option.label })
                 }
-                options={options()}
+                options={yellowOptions()}
                 placeholder="Select yellow team"
                 value={props.settings.yellowTeam.id}
               />
@@ -148,7 +191,7 @@ export function MatchSetupPanel(props: Readonly<MatchSetupPanelProps>) {
                 onChange={(value, option) =>
                   props.setSettings("blackTeam", { id: value, name: option.label })
                 }
-                options={options()}
+                options={blackOptions()}
                 placeholder="Select black team"
                 value={props.settings.blackTeam.id}
               />

--- a/src/components/home/MatchSetupPanel.tsx
+++ b/src/components/home/MatchSetupPanel.tsx
@@ -71,27 +71,35 @@ export function MatchSetupPanel(props: Readonly<MatchSetupPanelProps>) {
     opts.find((option) => option.value === id);
 
   createEffect(() => {
+    const ownIds = ownTeamIds();
     const availableOptions = options();
     if (!availableOptions.length) return;
 
-    const yellowOption =
-      optionById(availableOptions, props.settings.yellowTeam.id) ?? availableOptions[0];
-    const blackOption =
-      optionById(availableOptions, props.settings.blackTeam.id) ??
-      availableOptions[1] ??
-      yellowOption;
+    const yellowTeam = props.settings.yellowTeam;
+    const blackTeam = props.settings.blackTeam;
 
-    if (
-      yellowOption.value !== props.settings.yellowTeam.id ||
-      yellowOption.label !== props.settings.yellowTeam.name
-    ) {
+    const hasOwnTeams = ownIds.size > 0;
+    const yellowIsOwn = yellowTeam.id != null && ownIds.has(yellowTeam.id);
+    const blackIsOwn = blackTeam.id != null && ownIds.has(blackTeam.id);
+
+    const yellowOption =
+      hasOwnTeams && !yellowIsOwn
+        ? availableOptions[0]
+        : (optionById(availableOptions, yellowTeam.id) ?? availableOptions[0]);
+    const blackOption =
+      hasOwnTeams && !blackIsOwn
+        ? (availableOptions[1] ?? availableOptions[0])
+        : (optionById(availableOptions, blackTeam.id) ??
+          (availableOptions[1]?.value !== yellowOption.value
+            ? availableOptions[1]
+            : availableOptions[2]) ??
+          yellowOption);
+
+    if (yellowOption.value !== yellowTeam.id || yellowOption.label !== yellowTeam.name) {
       props.setSettings("yellowTeam", { id: yellowOption.value, name: yellowOption.label });
     }
 
-    if (
-      blackOption.value !== props.settings.blackTeam.id ||
-      blackOption.label !== props.settings.blackTeam.name
-    ) {
+    if (blackOption.value !== blackTeam.id || blackOption.label !== blackTeam.name) {
       props.setSettings("blackTeam", { id: blackOption.value, name: blackOption.label });
     }
   });

--- a/src/components/home/MatchSetupPanel.tsx
+++ b/src/components/home/MatchSetupPanel.tsx
@@ -78,11 +78,8 @@ export function MatchSetupPanel(props: Readonly<MatchSetupPanelProps>) {
     const yellowTeam = props.settings.yellowTeam;
     const blackTeam = props.settings.blackTeam;
 
-    const hasOwnTeams = ownIds.size > 0;
-    const yellowIsOwn = yellowTeam.id != null && ownIds.has(yellowTeam.id);
-
     const yellowOption =
-      hasOwnTeams && (yellowTeam.id == null || !yellowIsOwn)
+      ownIds.size > 0 && yellowTeam.id == null
         ? availableOptions[0]
         : (optionById(availableOptions, yellowTeam.id) ?? availableOptions[0]);
 

--- a/src/components/shared/Select.tsx
+++ b/src/components/shared/Select.tsx
@@ -1,53 +1,25 @@
-import { For, JSX, Show, splitProps } from "solid-js";
+import { createMemo, createSignal, For, onCleanup, onMount, Show, splitProps } from "solid-js";
 
 export interface Option<T extends string | number = string | number> {
   value: T;
   label: string;
   disabled?: boolean;
+  highlighted?: boolean;
 }
 
-export interface SelectProps<T extends string | number = string | number> extends Omit<
-  JSX.SelectHTMLAttributes<HTMLSelectElement>,
-  "onChange" | "value"
-> {
+export interface SelectProps<T extends string | number = string | number> {
   options: Option<T>[];
   value?: T;
-  /**
-   * Fires when an option is selected. The callback receives the new value
-   * and the fully matched option object. (The second argument is guaranteed
-   * to be a valid Option, never undefined.)
-   */
   onChange?: (value: T, option: Option<T>) => void;
   placeholder?: string;
   class?: string;
   legend?: string;
   label?: string;
+  "aria-label"?: string;
 }
 
-/**
- * A reusable Select component based on DaisyUI.
- *
- * @example
- * ```tsx
- * const options = [
- *   { value: "crimson", label: "Crimson" },
- *   { value: "amber", label: "Amber" },
- *   { value: "velvet", label: "Velvet" },
- * ];
- *
- * <Select
- *   options={options}
- *   placeholder="Pick a color"
- *   value={selectedValue}
- *   onChange={(newValue, matchedOption) => {
- *     setSelectedValue(newValue);
- *     console.log("Selected Option:", matchedOption);
- *   }}
- * />
- * ```
- */
-const Select = <T extends string | number = string>(props: Readonly<SelectProps<T>>) => {
-  const [local, others] = splitProps(props, [
+function Select<T extends string | number>(props: Readonly<SelectProps<T>>) {
+  const [local] = splitProps(props, [
     "options",
     "onChange",
     "value",
@@ -55,65 +27,107 @@ const Select = <T extends string | number = string>(props: Readonly<SelectProps<
     "class",
     "legend",
     "label",
+    "aria-label",
   ]);
+  const [open, setOpen] = createSignal(false);
+  let ref: HTMLDivElement | undefined;
 
-  const handleChange: JSX.EventHandler<HTMLSelectElement, Event> = (e) => {
-    const rawValue = e.currentTarget.value;
+  const selectedOption = createMemo(() => local.options.find((o) => o.value === local.value));
 
-    // If rawValue is empty (e.g. a placeholder was selected), we skip calling onChange.
-    if (!rawValue) {
-      return;
-    }
+  onMount(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref && !ref.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("click", handleClick);
+    onCleanup(() => document.removeEventListener("click", handleClick));
+  });
 
-    // Convert if the first option is numeric
-    const convertedValue =
-      typeof local.options[0]?.value === "number" ? (Number(rawValue) as T) : (rawValue as T);
-
-    // Find the matching option
-    const matchedOption = local.options.find((o) => o.value.toString() === rawValue);
-
-    // Only call onChange if we found a valid matching option.
-    // This ensures that when onChange fires, the second argument is never undefined.
-    if (matchedOption) {
-      local.onChange?.(convertedValue, matchedOption);
-    }
+  const handleSelect = (opt: Option<T>) => {
+    if (opt.disabled) return;
+    local.onChange?.(opt.value, opt);
+    setOpen(false);
   };
 
-  const selectElement = (
-    <select
-      {...others}
-      class={`select ${local.class ?? ""}`}
-      value={local.value?.toString() ?? ""}
-      onChange={handleChange}
+  const trigger = (
+    <button
+      aria-label={local["aria-label"]}
+      aria-haspopup="listbox"
+      aria-expanded={open()}
+      class={`btn select-bordered flex w-full items-center justify-between gap-2 font-normal ${local.class ?? ""}`}
+      onClick={() => setOpen((prev) => !prev)}
+      type="button"
     >
-      <Show when={local.placeholder && (local.value === undefined || local.value === "")}>
-        <option value="" disabled>
-          {local.placeholder}
-        </option>
-      </Show>
-      <For each={local.options}>
-        {(option) => (
-          <option value={option.value.toString()} disabled={option.disabled}>
-            {option.label}
-          </option>
-        )}
-      </For>
-    </select>
+      <span class={selectedOption() ? "" : "text-base-content/50"}>
+        {selectedOption()?.label || local.placeholder || ""}
+      </span>
+      <svg
+        class={`h-4 w-4 shrink-0 transition-transform ${open() ? "rotate-180" : ""}`}
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="m6 9 6 6 6-6" />
+      </svg>
+    </button>
+  );
+
+  const menu = (
+    <Show when={open()}>
+      <ul
+        class="bg-base-100 rounded-box border-base-300 absolute z-10 mt-1 w-full border shadow-md"
+        role="listbox"
+      >
+        <For each={local.options}>
+          {(option) => (
+            <li
+              role="option"
+              aria-selected={option.value === local.value}
+              aria-disabled={option.disabled}
+            >
+              <button
+                class={`hover:bg-base-200 flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${option.highlighted ? "font-bold" : ""} ${option.value === local.value ? "text-primary font-semibold" : ""} ${option.disabled ? "cursor-not-allowed opacity-40" : "cursor-pointer"}`}
+                disabled={option.disabled}
+                onClick={() => handleSelect(option)}
+                type="button"
+              >
+                <Show when={option.highlighted}>
+                  <span class="badge badge-primary badge-xs shrink-0" />
+                </Show>
+                <span class="truncate">{option.label}</span>
+              </button>
+            </li>
+          )}
+        </For>
+      </ul>
+    </Show>
+  );
+
+  const content = (
+    <div ref={ref} class="relative">
+      {trigger}
+      {menu}
+    </div>
   );
 
   return (
-    <Show when={local.legend || local.label} fallback={selectElement}>
+    <Show when={local.legend || local.label} fallback={content}>
       <fieldset class="fieldset">
         <Show when={local.legend}>
           <legend class="fieldset-legend">{local.legend}</legend>
         </Show>
-        {selectElement}
+        {content}
         <Show when={local.label}>
           <span class="fieldset-label">{local.label}</span>
         </Show>
       </fieldset>
     </Show>
   );
-};
+}
 
 export default Select;

--- a/src/components/shared/Select.tsx
+++ b/src/components/shared/Select.tsx
@@ -55,6 +55,7 @@ function Select<T extends string | number>(props: Readonly<SelectProps<T>>) {
       aria-label={local["aria-label"]}
       aria-haspopup="listbox"
       aria-expanded={open()}
+      aria-controls="select-menu"
       class={`btn select-bordered flex w-full items-center justify-between gap-2 font-normal ${local.class ?? ""}`}
       onClick={() => setOpen((prev) => !prev)}
       type="button"
@@ -79,13 +80,14 @@ function Select<T extends string | number>(props: Readonly<SelectProps<T>>) {
 
   const menu = (
     <Show when={open()}>
-      <ul
+      <div
+        id="select-menu"
         class="bg-base-100 rounded-box border-base-300 absolute z-10 mt-1 w-full border shadow-md"
         role="listbox"
       >
         <For each={local.options}>
           {(option) => (
-            <li
+            <div
               role="option"
               aria-selected={option.value === local.value}
               aria-disabled={option.disabled}
@@ -101,10 +103,10 @@ function Select<T extends string | number>(props: Readonly<SelectProps<T>>) {
                 </Show>
                 <span class="truncate">{option.label}</span>
               </button>
-            </li>
+            </div>
           )}
         </For>
-      </ul>
+      </div>
     </Show>
   );
 

--- a/src/components/teams/TeamForm.tsx
+++ b/src/components/teams/TeamForm.tsx
@@ -13,7 +13,7 @@ import {
 import { useParams, useNavigate } from "@solidjs/router";
 import Spinner from "../shared/Spinner";
 import { createTeam, updateTeam, getTeamWithMembers } from "~/service/teamService";
-import { getPlayers } from "~/service/playerService";
+import { getCurrentPlayerId, getPlayers } from "~/service/playerService";
 import { useTeamListContext } from "./TeamListContext";
 
 export interface TeamEditData {
@@ -38,6 +38,7 @@ export default function TeamForm() {
   const hasValidTeamId = () => teamId() !== undefined;
 
   const [players] = createResource(getPlayers);
+  const [currentPlayerId] = createResource(getCurrentPlayerId);
   const [teamData] = createResource(teamId, async (id) => {
     if (!id) return null;
     return getTeamWithMembers(id);
@@ -108,6 +109,16 @@ export default function TeamForm() {
     }
   };
 
+  const playerOptions = createMemo(() => {
+    const allPlayers = players() ?? [];
+    const currentId = currentPlayerId();
+    return [...allPlayers].sort((a, b) => {
+      if (a.id === currentId && b.id !== currentId) return -1;
+      if (b.id === currentId && a.id !== currentId) return 1;
+      return 0;
+    });
+  });
+
   const handlePlayerSelect: JSX.EventHandler<HTMLSelectElement, Event> = (e) => {
     const value = Number.parseInt(e.currentTarget.value);
     if (!isNaN(value) && !selectedPlayerIds().includes(value)) {
@@ -149,8 +160,12 @@ export default function TeamForm() {
               disabled={isSubmitting()}
             >
               <option value="">Select player...</option>
-              <For each={players() ?? []}>
-                {(player) => <option value={player.id}>{player.name}</option>}
+              <For each={playerOptions()}>
+                {(player) => (
+                  <option value={player.id}>
+                    {player.id === currentPlayerId() ? `${player.name} (You)` : player.name}
+                  </option>
+                )}
               </For>
             </select>
           </fieldset>
@@ -158,12 +173,12 @@ export default function TeamForm() {
           <div class="mt-2 flex flex-wrap gap-2">
             <For each={selectedPlayerIds()}>
               {(id) => {
-                const playerName = createMemo(
-                  () => players()?.find((p) => p.id === id)?.name ?? "Unknown"
-                );
+                const player = createMemo(() => players()?.find((p) => p.id === id));
                 return (
                   <div class="badge badge-primary badge-soft gap-2 p-3">
-                    {playerName()}
+                    {player()?.id === currentPlayerId()
+                      ? `${player()?.name ?? "Unknown"} (You)`
+                      : (player()?.name ?? "Unknown")}
                     <button
                       type="button"
                       class="btn btn-xs btn-circle btn-ghost ml-2"

--- a/src/service/playerService.ts
+++ b/src/service/playerService.ts
@@ -44,6 +44,21 @@ export const createPlayer = async (params: CreatePlayerParams) => {
 };
 
 /**
+ * Fetches the current authenticated user's player ID, or null if not linked.
+ */
+export const getCurrentPlayerId = async (): Promise<number | null> => {
+  if (!supabase) return null;
+  const { data, error } = await supabase.rpc("current_player_id");
+
+  if (error) {
+    console.error("Error fetching current player ID:", error);
+    return null;
+  }
+
+  return data ?? null;
+};
+
+/**
  * Fetches all players from the database
  * @returns Array of players
  */

--- a/src/service/teamService.ts
+++ b/src/service/teamService.ts
@@ -1,6 +1,38 @@
 import { requireSupabase, supabase } from "./supabaseService";
 import type { Tables } from "~/types/database";
 
+export const getTeamIdsForPlayer = async (playerId: number): Promise<number[]> => {
+  if (!supabase) return [];
+
+  const { data: playerTeams, error: playerError } = await supabase
+    .from("teams")
+    .select("id")
+    .eq("type", "player")
+    .eq("player_id", playerId);
+
+  if (playerError) {
+    console.error("Error fetching player teams:", playerError);
+    return [];
+  }
+
+  const { data: memberTeams, error: memberError } = await supabase
+    .from("team_members")
+    .select("team_id")
+    .eq("player_id", playerId);
+
+  if (memberError) {
+    console.error("Error fetching member teams:", memberError);
+    return [];
+  }
+
+  const ids = new Set([
+    ...(playerTeams ?? []).map((t) => t.id),
+    ...(memberTeams ?? []).map((m) => m.team_id),
+  ]);
+
+  return [...ids];
+};
+
 export interface TeamMember {
   player_id: number;
   players: { name: string } | null;


### PR DESCRIPTION
Closes #54

## Changes

- **playerService**: Added `getCurrentPlayerId()` calling the existing `current_player_id()` RPC
- **teamService**: Added `getTeamIdsForPlayer()` querying both player-linked and member teams
- **ProtectedApp**: Loads current player info and passes it to MatchSetupPanel; guards startGame against same-team matches
- **MatchSetupPanel**: Sorts teams so current user teams appear first with `(You)` label; disables already-selected opposite-side option
- **TeamForm**: Sorts players with current user first, labels them `(You)` in dropdown and badges