### PR TITLE
feat: add global mute toggle for game sounds (#47)

### DIFF
--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -11,11 +11,14 @@ import {
   RefreshCw,
   RotateCcw,
   Timer,
+  Volume2,
+  VolumeX,
 } from "lucide-solid";
 import { createMemo, createSignal, onCleanup, onMount, Show } from "solid-js";
 import { GoalHistoryCard } from "~/components/home/GoalHistoryCard.tsx";
 import { TeamScore } from "~/components/TeamScore";
 import { formatTime } from "~/lib/utils.ts";
+import { isMuted, toggleMute } from "~/service/soundService.ts";
 import type { ISettings } from "~/types/Settings";
 import type { Tables } from "~/types/database";
 
@@ -264,6 +267,15 @@ export function ScoreBoard(props: Readonly<ScoreBoardProps>) {
                 >
                   <RotateCcw size={18} />
                   Reset
+                </button>
+                <button
+                  aria-label={isMuted() ? "Unmute game sounds" : "Mute game sounds"}
+                  class={actionButtonClasses("subtle")}
+                  onClick={() => toggleMute()}
+                  type="button"
+                >
+                  {isMuted() ? <VolumeX size={18} /> : <Volume2 size={18} />}
+                  {isMuted() ? "Sound off" : "Sound on"}
                 </button>
               </div>
             }

--- a/src/service/soundService.ts
+++ b/src/service/soundService.ts
@@ -1,4 +1,30 @@
+import { createSignal } from "solid-js";
+
 export type SoundType = "goal" | "no-goal" | "win";
+
+const MUTE_STORAGE_KEY = "foosball-muted";
+
+function loadMuteState(): boolean {
+  try {
+    return localStorage.getItem(MUTE_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+const [isMuted, setIsMuted] = createSignal(loadMuteState());
+
+export { isMuted };
+
+export function toggleMute() {
+  const next = !isMuted();
+  setIsMuted(next);
+  try {
+    localStorage.setItem(MUTE_STORAGE_KEY, String(next));
+  } catch {
+    // localStorage may be unavailable in some environments
+  }
+}
 
 class SoundService {
   // Keep track of the last 5 picks per sound type (not needed for "win").
@@ -60,6 +86,7 @@ const soundService = new SoundService({
 export default soundService;
 
 export function playSound(type: SoundType) {
+  if (isMuted()) return;
   const soundUrl = soundService.getSoundPath(type);
   console.log("playing sound url", soundUrl);
   const audio = new Audio(soundUrl);


### PR DESCRIPTION
Closes #47

## Summary

Adds a global sound on/off toggle visible during active games. When muted, all game sounds (goal, no-goal, win, and future sounds) are skipped without affecting game state.

## Changes

- **`src/service/soundService.ts`**: Added reactive `isMuted` signal (SolidJS), persisted via `localStorage`. The `playSound()` function checks mute state before playing any audio.
- **`src/components/ScoreBoard.tsx`**: Added "Sound on/off" toggle button in the active game controls row, next to Pause and Reset. Uses `Volume2`/`VolumeX` icons from lucide-solid.

## Design

- Uses existing `actionButtonClasses("subtle")` for visual consistency with the Reset button
- Accessible: dynamic `aria-label` changes between "Mute game sounds" / "Unmute game sounds"
- Mute preference persists across page refreshes via `localStorage`
- No prop threading needed — ScoreBoard imports the signal directly from the service