### PR TITLE
feat: add Supabase-backed sound management (#52)

### DIFF
--- a/e2e/auth-integration.spec.ts
+++ b/e2e/auth-integration.spec.ts
@@ -30,7 +30,9 @@ test.describe("authenticated auth integration", () => {
   test("login page supports configured auth mode switching", async ({ page }) => {
     test.skip(!hasAuth, "No auth state found. Run `pnpm auth:local` first.");
 
-    await page.goto("/login");
+    await page.goto("/");
+    await page.getByRole("button", { name: "Logout" }).click();
+    await page.waitForURL("**/login");
     await exerciseConfiguredModeSwitching(page);
   });
 });

--- a/e2e/auth-integration.spec.ts
+++ b/e2e/auth-integration.spec.ts
@@ -33,8 +33,8 @@ test.describe("authenticated auth integration", () => {
     await page.goto("/");
     await page.context().clearCookies();
     await page.evaluate(() => {
-      window.localStorage.clear();
-      window.sessionStorage.clear();
+      globalThis.localStorage.clear();
+      globalThis.sessionStorage.clear();
     });
     await page.goto("/login");
 

--- a/e2e/auth-integration.spec.ts
+++ b/e2e/auth-integration.spec.ts
@@ -11,9 +11,10 @@ test.describe("authenticated auth integration", () => {
     await page.goto("/");
     await expect(page.locator("body")).toContainText(/Foosball/i);
 
-    const logoutButton = page.getByRole("button", { name: "Logout" });
-    const signInButton = page.getByRole("button", { name: /^sign in$/i });
-    await expect(page.getByRole("button", { name: /logout|sign in/i }).first()).toBeVisible();
+    const header = page.getByRole("banner");
+    const logoutButton = header.getByRole("button", { name: "Logout" });
+    const signInButton = header.getByRole("button", { name: /^sign in$/i });
+    await expect(header.getByRole("button", { name: /logout|sign in/i }).first()).toBeVisible();
 
     test.skip(
       !(await logoutButton.isVisible().catch(() => false)) &&
@@ -22,7 +23,6 @@ test.describe("authenticated auth integration", () => {
     );
 
     await expect(logoutButton).toBeVisible();
-    await expect(signInButton).not.toBeVisible();
 
     await page.screenshot({ path: "test-results/authenticated-home.png" });
   });
@@ -30,9 +30,17 @@ test.describe("authenticated auth integration", () => {
   test("login page supports configured auth mode switching", async ({ page }) => {
     test.skip(!hasAuth, "No auth state found. Run `pnpm auth:local` first.");
 
-    await page.goto("/");
-    await page.getByRole("button", { name: "Logout" }).click();
-    await page.waitForURL("**/login");
+    const header = page.getByRole("banner");
+
+    await page.goto("/login");
+
+    if (!page.url().includes("/login")) {
+      const logoutButton = header.getByRole("button", { name: "Logout" });
+      await expect(logoutButton).toBeVisible();
+      await logoutButton.click();
+      await page.waitForURL("**/login");
+    }
+
     await exerciseConfiguredModeSwitching(page);
   });
 });

--- a/e2e/auth-integration.spec.ts
+++ b/e2e/auth-integration.spec.ts
@@ -30,16 +30,13 @@ test.describe("authenticated auth integration", () => {
   test("login page supports configured auth mode switching", async ({ page }) => {
     test.skip(!hasAuth, "No auth state found. Run `pnpm auth:local` first.");
 
-    const header = page.getByRole("banner");
-
+    await page.goto("/");
+    await page.context().clearCookies();
+    await page.evaluate(() => {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+    });
     await page.goto("/login");
-
-    if (!page.url().includes("/login")) {
-      const logoutButton = header.getByRole("button", { name: "Logout" });
-      await expect(logoutButton).toBeVisible();
-      await logoutButton.click();
-      await page.waitForURL("**/login");
-    }
 
     await exerciseConfiguredModeSwitching(page);
   });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "db:migration:new": "supabase migration new",
     "db-types": "supabase gen types typescript --local --schema public > src/types/database.ts",
     "db:seed:auth": "tsx scripts/seed-local-auth.ts",
+    "db:seed:sounds": "node scripts/seed-local-sounds.mjs",
     "local:setup": "pnpm supabase:start && pnpm db:reset && node scripts/local-auth-seed.mjs",
     "local:reset": "pnpm db:reset && node scripts/local-auth-seed.mjs",
     "local:dev": "node scripts/local-dev.mjs",

--- a/scripts/lib/mp3-duration.mjs
+++ b/scripts/lib/mp3-duration.mjs
@@ -1,0 +1,177 @@
+const BITRATE_INDEXES = {
+  V1L1: [0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448],
+  V1L2: [0, 32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384],
+  V1L3: [0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320],
+  V2L1: [0, 32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256],
+  V2L2: [0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160],
+  V2L3: [0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160],
+};
+
+const SAMPLE_RATES = {
+  V1: [44100, 48000, 32000],
+  V2: [22050, 24000, 16000],
+  V25: [11025, 12000, 8000],
+};
+
+function readSynchsafeInteger(buffer, offset) {
+  return (
+    ((buffer[offset] & 0x7f) << 21) |
+    ((buffer[offset + 1] & 0x7f) << 14) |
+    ((buffer[offset + 2] & 0x7f) << 7) |
+    (buffer[offset + 3] & 0x7f)
+  );
+}
+
+function skipId3Tag(buffer) {
+  if (buffer.length < 10) return 0;
+  if (buffer.toString("ascii", 0, 3) !== "ID3") return 0;
+
+  const flags = buffer[5];
+  const size = readSynchsafeInteger(buffer, 6);
+  const footerSize = flags & 0x10 ? 10 : 0;
+
+  return 10 + size + footerSize;
+}
+
+function getVersion(versionBits) {
+  if (versionBits === 0b11) return "V1";
+  if (versionBits === 0b10) return "V2";
+  if (versionBits === 0b00) return "V25";
+  return null;
+}
+
+function getLayer(layerBits) {
+  if (layerBits === 0b11) return "L1";
+  if (layerBits === 0b10) return "L2";
+  if (layerBits === 0b01) return "L3";
+  return null;
+}
+
+function getBitrate(version, layer, bitrateIndex) {
+  if (bitrateIndex <= 0 || bitrateIndex >= 0b1111) return null;
+
+  const key =
+    version === "V1"
+      ? `${version}${layer}`
+      : layer === "L1"
+        ? "V2L1"
+        : layer === "L2"
+          ? "V2L2"
+          : "V2L3";
+
+  return BITRATE_INDEXES[key][bitrateIndex - 1] * 1000;
+}
+
+function getSampleRate(version, sampleRateIndex) {
+  if (sampleRateIndex >= 0b11) return null;
+  return SAMPLE_RATES[version][sampleRateIndex];
+}
+
+function getSamplesPerFrame(version, layer) {
+  if (layer === "L1") return 384;
+  if (layer === "L2") return 1152;
+  if (version === "V1") return 1152;
+  return 576;
+}
+
+function getFrameLength(version, layer, bitrate, sampleRate, paddingBit) {
+  if (layer === "L1") {
+    return Math.floor(((12 * bitrate) / sampleRate + paddingBit) * 4);
+  }
+
+  if (layer === "L3" && version !== "V1") {
+    return Math.floor((72 * bitrate) / sampleRate + paddingBit);
+  }
+
+  return Math.floor((144 * bitrate) / sampleRate + paddingBit);
+}
+
+function readFrameCountFromVbrHeader(buffer, frameStart, version, channelMode) {
+  const sideInfoSize =
+    version === "V1" ? (channelMode === 0b11 ? 17 : 32) : channelMode === 0b11 ? 9 : 17;
+  const xingOffset = frameStart + 4 + sideInfoSize;
+
+  if (xingOffset + 16 <= buffer.length) {
+    const marker = buffer.toString("ascii", xingOffset, xingOffset + 4);
+    if (marker === "Xing" || marker === "Info") {
+      const flags = buffer.readUInt32BE(xingOffset + 4);
+      const hasFrames = (flags & 0x0001) !== 0;
+      if (hasFrames) {
+        return buffer.readUInt32BE(xingOffset + 8);
+      }
+    }
+  }
+
+  const vbriOffset = frameStart + 36;
+  if (vbriOffset + 18 <= buffer.length) {
+    const marker = buffer.toString("ascii", vbriOffset, vbriOffset + 4);
+    if (marker === "VBRI") {
+      return buffer.readUInt32BE(vbriOffset + 14);
+    }
+  }
+
+  return null;
+}
+
+export function getMp3DurationMs(buffer) {
+  let offset = skipId3Tag(buffer);
+  let totalSamples = 0;
+  let detectedSampleRate = null;
+
+  while (offset + 4 <= buffer.length) {
+    const header = buffer.readUInt32BE(offset);
+
+    if ((header & 0xffe00000) !== 0xffe00000) {
+      offset += 1;
+      continue;
+    }
+
+    const versionBits = (header >> 19) & 0b11;
+    const layerBits = (header >> 17) & 0b11;
+    const bitrateIndex = (header >> 12) & 0b1111;
+    const sampleRateIndex = (header >> 10) & 0b11;
+    const paddingBit = (header >> 9) & 0b1;
+    const channelMode = (header >> 6) & 0b11;
+
+    const version = getVersion(versionBits);
+    const layer = getLayer(layerBits);
+
+    if (!version || !layer) {
+      offset += 1;
+      continue;
+    }
+
+    const bitrate = getBitrate(version, layer, bitrateIndex);
+    const sampleRate = getSampleRate(version, sampleRateIndex);
+
+    if (!bitrate || !sampleRate) {
+      offset += 1;
+      continue;
+    }
+
+    const samplesPerFrame = getSamplesPerFrame(version, layer);
+    const frameLength = getFrameLength(version, layer, bitrate, sampleRate, paddingBit);
+
+    if (!frameLength || offset + frameLength > buffer.length) {
+      break;
+    }
+
+    if (totalSamples === 0) {
+      const frameCount = readFrameCountFromVbrHeader(buffer, offset, version, channelMode);
+      if (frameCount) {
+        return Math.round((frameCount * samplesPerFrame * 1000) / sampleRate);
+      }
+    }
+
+    detectedSampleRate ??= sampleRate;
+    totalSamples += samplesPerFrame;
+    offset += frameLength;
+  }
+
+  if (totalSamples === 0 || !detectedSampleRate) {
+    throw new Error("Could not determine MP3 duration.");
+  }
+
+  const durationSeconds = totalSamples / detectedSampleRate;
+  return Math.round(durationSeconds * 1000);
+}

--- a/scripts/lib/mp3-duration.mjs
+++ b/scripts/lib/mp3-duration.mjs
@@ -50,16 +50,19 @@ function getLayer(layerBits) {
 function getBitrate(version, layer, bitrateIndex) {
   if (bitrateIndex <= 0 || bitrateIndex >= 0b1111) return null;
 
-  const key =
-    version === "V1"
-      ? `${version}${layer}`
-      : layer === "L1"
-        ? "V2L1"
-        : layer === "L2"
-          ? "V2L2"
-          : "V2L3";
+  let key;
 
-  return BITRATE_INDEXES[key][bitrateIndex - 1] * 1000;
+  if (version === "V1") {
+    key = `${version}${layer}`;
+  } else if (layer === "L1") {
+    key = "V2L1";
+  } else if (layer === "L2") {
+    key = "V2L2";
+  } else {
+    key = "V2L3";
+  }
+
+  return BITRATE_INDEXES[key][bitrateIndex] * 1000;
 }
 
 function getSampleRate(version, sampleRateIndex) {
@@ -87,8 +90,13 @@ function getFrameLength(version, layer, bitrate, sampleRate, paddingBit) {
 }
 
 function readFrameCountFromVbrHeader(buffer, frameStart, version, channelMode) {
-  const sideInfoSize =
-    version === "V1" ? (channelMode === 0b11 ? 17 : 32) : channelMode === 0b11 ? 9 : 17;
+  let sideInfoSize;
+
+  if (version === "V1") {
+    sideInfoSize = channelMode === 0b11 ? 17 : 32;
+  } else {
+    sideInfoSize = channelMode === 0b11 ? 9 : 17;
+  }
   const xingOffset = frameStart + 4 + sideInfoSize;
 
   if (xingOffset + 16 <= buffer.length) {

--- a/scripts/lib/utils.mjs
+++ b/scripts/lib/utils.mjs
@@ -208,6 +208,7 @@ function spawnViteDevServer({ port, host, viteEnv }) {
 export {
   DEFAULT_LOCAL_TEST_PASSWORD,
   DEFAULT_LOCAL_AUTH_EMAIL,
+  PNPM_BIN,
   createLocalAuthSeedEnv,
   createLimitedViteEnv,
   createLocalViteEnv,

--- a/scripts/local-auth-seed.mjs
+++ b/scripts/local-auth-seed.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import {
   DEFAULT_LOCAL_TEST_PASSWORD,
+  PNPM_BIN,
   createLocalAuthSeedEnv,
   getLocalSupabaseStatus,
 } from "./lib/utils.mjs";
@@ -11,7 +12,7 @@ const password = process.env.LOCAL_TEST_USER_PASSWORD ?? DEFAULT_LOCAL_TEST_PASS
 process.stdout.write(statusOutput);
 console.log(`Seeding local auth users with LOCAL_TEST_USER_PASSWORD=${password}`);
 
-const result = spawnSync("pnpm", ["db:seed:auth"], {
+const result = spawnSync(PNPM_BIN, ["db:seed:auth"], {
   // NOSONAR - local dev script only
   stdio: "inherit",
   env: {
@@ -25,7 +26,7 @@ if (result.status !== 0) {
   process.exit(result.status ?? 1);
 }
 
-const soundSeedResult = spawnSync("pnpm", ["db:seed:sounds"], {
+const soundSeedResult = spawnSync(PNPM_BIN, ["db:seed:sounds"], {
   // NOSONAR - local dev script only
   stdio: "inherit",
   env: {

--- a/scripts/local-auth-seed.mjs
+++ b/scripts/local-auth-seed.mjs
@@ -25,6 +25,21 @@ if (result.status !== 0) {
   process.exit(result.status ?? 1);
 }
 
+const soundSeedResult = spawnSync("pnpm", ["db:seed:sounds"], {
+  // NOSONAR - local dev script only
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    SUPABASE_SERVICE_ROLE_KEY: localStatus.SERVICE_ROLE_KEY,
+    SUPABASE_URL: localStatus.API_URL,
+    VITE_SUPABASE_URL: localStatus.API_URL,
+  },
+});
+
+if (soundSeedResult.status !== 0) {
+  process.exit(soundSeedResult.status ?? 1);
+}
+
 console.log();
 console.log("Local login credentials:");
 console.log(`  Password: ${password}`);

--- a/scripts/seed-local-sounds.mjs
+++ b/scripts/seed-local-sounds.mjs
@@ -8,6 +8,7 @@ import { getMp3DurationMs } from "./lib/mp3-duration.mjs";
 const supabaseUrl = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const SOUND_BUCKET = "sounds";
+const FILE_BIN = "/usr/bin/file";
 
 if (!supabaseUrl?.includes("127.0.0.1") && !supabaseUrl?.includes("localhost")) {
   console.error("Error: Refusing to seed sounds outside local Supabase.");
@@ -43,7 +44,7 @@ function checksumFor(buffer) {
 }
 
 function getDurationFromFileCommand(filePath, sizeBytes) {
-  const result = spawnSync("file", [filePath], {
+  const result = spawnSync(FILE_BIN, [filePath], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/scripts/seed-local-sounds.mjs
+++ b/scripts/seed-local-sounds.mjs
@@ -1,0 +1,129 @@
+import { createHash, randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { createClient } from "@supabase/supabase-js";
+import { getMp3DurationMs } from "./lib/mp3-duration.mjs";
+
+const supabaseUrl = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const SOUND_BUCKET = "sounds";
+
+if (!supabaseUrl?.includes("127.0.0.1") && !supabaseUrl?.includes("localhost")) {
+  console.error("Error: Refusing to seed sounds outside local Supabase.");
+  console.error(`  SUPABASE_URL="${supabaseUrl ?? "(not set)"}"`);
+  process.exit(1);
+}
+
+if (!serviceRoleKey) {
+  console.error("Error: Missing SUPABASE_SERVICE_ROLE_KEY environment variable.");
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+function getSeedFiles(type) {
+  const directory = join(process.cwd(), "public", "audio", type);
+
+  return readdirSync(directory)
+    .filter((name) => name.endsWith(".mp3"))
+    .sort()
+    .map((name) => ({ name, path: join(directory, name) }));
+}
+
+function getDisplayName(type, index) {
+  const prefix = type === "goal" ? "Goal" : "Win";
+  return `${prefix} ${index + 1}`;
+}
+
+function checksumFor(buffer) {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+function getDurationFromFileCommand(filePath, sizeBytes) {
+  const result = spawnSync("file", [filePath], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`file command failed for ${filePath}: ${result.stderr}`);
+  }
+
+  const match = result.stdout.match(/,\s+(\d+)\s+kbps,/i);
+  if (!match) {
+    throw new Error(`Could not parse bitrate from file output for ${filePath}.`);
+  }
+
+  const bitrate = Number.parseInt(match[1], 10) * 1000;
+  return Math.round((sizeBytes * 8 * 1000) / bitrate);
+}
+
+async function seedType(type) {
+  const files = getSeedFiles(type);
+
+  for (const [index, file] of files.entries()) {
+    const buffer = readFileSync(file.path);
+    const checksum = checksumFor(buffer);
+    const soundId = randomUUID();
+    const storagePath = `ready/${soundId}/${checksum}.mp3`;
+    let durationMs;
+
+    try {
+      durationMs = getMp3DurationMs(buffer);
+    } catch {
+      durationMs = getDurationFromFileCommand(file.path, buffer.byteLength);
+    }
+
+    const { error: uploadError } = await supabase.storage
+      .from(SOUND_BUCKET)
+      .upload(storagePath, buffer, {
+        contentType: "audio/mpeg",
+        upsert: false,
+      });
+
+    if (uploadError) {
+      throw new Error(`Failed to upload ${file.name}: ${uploadError.message}`);
+    }
+
+    const { error: insertError } = await supabase.from("sound_assets").insert({
+      id: soundId,
+      type,
+      status: "ready",
+      name: getDisplayName(type, index),
+      storage_bucket: SOUND_BUCKET,
+      storage_path: storagePath,
+      content_type: "audio/mpeg",
+      size_bytes: buffer.byteLength,
+      duration_ms: durationMs,
+      checksum,
+      is_default: true,
+      metadata: {
+        seeded: true,
+        source_file: `public/audio/${type}/${file.name}`,
+      },
+    });
+
+    if (insertError) {
+      throw new Error(`Failed to insert ${file.name}: ${insertError.message}`);
+    }
+  }
+}
+
+console.log(`Seeding local sound assets on ${supabaseUrl} ...`);
+
+const { error: deleteSeededError } = await supabase
+  .from("sound_assets")
+  .delete()
+  .contains("metadata", { seeded: true });
+
+if (deleteSeededError) {
+  throw new Error(`Failed to clear seeded sound rows: ${deleteSeededError.message}`);
+}
+
+await seedType("goal");
+await seedType("win");
+
+console.log("Done. Seeded goal and win sound assets.");

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,9 +1,10 @@
 import { A, useLocation } from "@solidjs/router";
-import { Medal, Menu, UserRound, UsersRound } from "lucide-solid";
-import { createSignal, For } from "solid-js";
+import { Medal, Menu, UserRound, UsersRound, Volume2 } from "lucide-solid";
+import { createMemo, createResource, createSignal, For } from "solid-js";
 import { Login } from "~/components/auth/Login.tsx";
 import { SupabaseConnectionBadge } from "~/components/SupabaseConnectionBadge.tsx";
 import { ThemeSwitch } from "~/components/ThemeSwitch.tsx";
+import { getCurrentProfile } from "~/service/profileService.ts";
 
 const navItems = [
   { href: "/players", label: "Players", icon: UserRound },
@@ -13,10 +14,16 @@ const navItems = [
 
 export function AppHeader() {
   const [isMenuOpen, setIsMenuOpen] = createSignal(false);
+  const [profile] = createResource(getCurrentProfile);
   const location = useLocation();
 
   const closeMenu = () => setIsMenuOpen(false);
   const isCurrentPath = (href: string) => location.pathname.startsWith(href);
+  const visibleNavItems = createMemo(() =>
+    profile()?.is_admin
+      ? [...navItems, { href: "/sounds", label: "Sounds", icon: Volume2 }]
+      : navItems
+  );
 
   return (
     <header class="border-base-300/80 bg-base-100/95 sticky top-0 z-30 border-b shadow-sm backdrop-blur">
@@ -34,7 +41,7 @@ export function AppHeader() {
               <Menu class="h-5 w-5" />
             </summary>
             <ul class="menu menu-sm dropdown-content rounded-box border-base-300 bg-base-100 z-40 mt-3 w-56 border p-2 shadow-lg">
-              <For each={navItems}>
+              <For each={visibleNavItems()}>
                 {(item) => (
                   <li>
                     <A
@@ -63,7 +70,7 @@ export function AppHeader() {
 
         <nav class="navbar-center hidden lg:flex" aria-label="Primary navigation">
           <ul class="menu menu-horizontal gap-1 px-1">
-            <For each={navItems}>
+            <For each={visibleNavItems()}>
               {(item) => (
                 <li>
                   <A

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -4,6 +4,7 @@ import { createMemo, createResource, createSignal, For } from "solid-js";
 import { Login } from "~/components/auth/Login.tsx";
 import { SupabaseConnectionBadge } from "~/components/SupabaseConnectionBadge.tsx";
 import { ThemeSwitch } from "~/components/ThemeSwitch.tsx";
+import { useAuthSession } from "~/hooks/useAuthSession.ts";
 import { getCurrentProfile } from "~/service/profileService.ts";
 
 const navItems = [
@@ -14,7 +15,11 @@ const navItems = [
 
 export function AppHeader() {
   const [isMenuOpen, setIsMenuOpen] = createSignal(false);
-  const [profile] = createResource(getCurrentProfile);
+  const { session } = useAuthSession();
+  const [profile] = createResource(
+    () => session()?.user.id ?? null,
+    async (userId) => (userId ? getCurrentProfile() : null)
+  );
   const location = useLocation();
 
   const closeMenu = () => setIsMenuOpen(false);

--- a/src/components/ProtectedApp.tsx
+++ b/src/components/ProtectedApp.tsx
@@ -7,7 +7,7 @@ import { HomeShell } from "~/components/home/HomeShell.tsx";
 import { MatchSetupPanel } from "~/components/home/MatchSetupPanel.tsx";
 import type { ISettings } from "../types/Settings.ts";
 import * as matchService from "../service/matchService";
-import { playSound } from "~/service/soundService.ts";
+import { playSound, refreshSoundAssets } from "~/service/soundService.ts";
 import { getSupabaseSchemaIssue } from "~/service/supabaseService.ts";
 import { getAllTeams, getTeamIdsForPlayer, getTeamsByIds } from "~/service/teamService.ts";
 import { getCurrentPlayerId } from "~/service/playerService.ts";
@@ -300,6 +300,7 @@ export default function ProtectedApp() {
   };
 
   onMount(() => {
+    void refreshSoundAssets();
     void hydrateActiveMatch();
     onCleanup(() => stop());
   });

--- a/src/components/sounds/SoundsPage.tsx
+++ b/src/components/sounds/SoundsPage.tsx
@@ -49,6 +49,7 @@ export default function SoundsPage() {
   const [submitSuccess, setSubmitSuccess] = createSignal<string | null>(null);
   const [isSubmitting, setIsSubmitting] = createSignal(false);
   const [updatingIds, setUpdatingIds] = createSignal<string[]>([]);
+  let fileInput: HTMLInputElement | undefined;
 
   const typeLimitLabel = createMemo(() => (type() === "goal" ? "Max 5s" : "Max 10s"));
   const selectedFileSizeLabel = createMemo(() => {
@@ -130,6 +131,9 @@ export default function SoundsPage() {
     setSubmitError(null);
     setSubmitSuccess(null);
     clearPreview();
+    if (fileInput) {
+      fileInput.value = "";
+    }
   };
 
   const handleUpload = async (event: Event) => {
@@ -257,6 +261,7 @@ export default function SoundsPage() {
                         accept=".mp3,audio/mpeg"
                         class="file-input file-input-bordered w-full"
                         onChange={(event) => void handleFileChange(event)}
+                        ref={fileInput}
                         type="file"
                       />
                     </fieldset>

--- a/src/components/sounds/SoundsPage.tsx
+++ b/src/components/sounds/SoundsPage.tsx
@@ -1,0 +1,454 @@
+import {
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  Match,
+  onCleanup,
+  Show,
+  Switch,
+} from "solid-js";
+import { AudioLines, Upload, Volume2, VolumeX } from "lucide-solid";
+import { HomeShell } from "~/components/home/HomeShell.tsx";
+import Spinner from "~/components/shared/Spinner.tsx";
+import { getCurrentProfile } from "~/service/profileService.ts";
+import {
+  createSoundAsset,
+  listSoundAssets,
+  type ManagedSoundType,
+  updateSoundAssetStatus,
+  validateSoundUpload,
+} from "~/service/soundService.ts";
+
+function formatBytes(sizeBytes: number) {
+  if (sizeBytes < 1024) return `${sizeBytes} B`;
+  if (sizeBytes < 1024 * 1024) return `${(sizeBytes / 1024).toFixed(1)} KB`;
+  return `${(sizeBytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function formatDuration(durationMs: number) {
+  return `${(durationMs / 1000).toFixed(2)}s`;
+}
+
+export default function SoundsPage() {
+  const [profile] = createResource(getCurrentProfile);
+  const [soundAssets, { refetch }] = createResource(
+    () => profile()?.is_admin ?? false,
+    async (isAdmin) => (isAdmin ? listSoundAssets({ includeDisabled: true }) : [])
+  );
+
+  const [type, setType] = createSignal<ManagedSoundType>("goal");
+  const [name, setName] = createSignal("");
+  const [selectedFile, setSelectedFile] = createSignal<File | null>(null);
+  const [previewUrl, setPreviewUrl] = createSignal<string | null>(null);
+  const [previewDurationMs, setPreviewDurationMs] = createSignal<number | null>(null);
+  const [submitError, setSubmitError] = createSignal<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = createSignal<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = createSignal(false);
+  const [updatingIds, setUpdatingIds] = createSignal<string[]>([]);
+
+  const typeLimitLabel = createMemo(() => (type() === "goal" ? "Max 5s" : "Max 10s"));
+
+  const clearPreview = () => {
+    const url = previewUrl();
+    if (url) {
+      URL.revokeObjectURL(url);
+    }
+    setPreviewUrl(null);
+    setPreviewDurationMs(null);
+  };
+
+  onCleanup(() => clearPreview());
+
+  const handleFileChange = async (event: Event) => {
+    const file =
+      event.currentTarget instanceof HTMLInputElement ? event.currentTarget.files?.[0] : null;
+    clearPreview();
+    setSelectedFile(file ?? null);
+    setSubmitError(null);
+    setSubmitSuccess(null);
+
+    if (!file) return;
+
+    setPreviewUrl(URL.createObjectURL(file));
+
+    try {
+      const validation = await validateSoundUpload(file, type());
+      setPreviewDurationMs(validation.durationMs);
+      if (!name().trim()) {
+        const baseName = file.name.replace(/\.mp3$/i, "");
+        setName(baseName);
+      }
+    } catch (error) {
+      setPreviewDurationMs(null);
+      setSubmitError(
+        error instanceof Error ? error.message : "Could not validate the selected file."
+      );
+    }
+  };
+
+  const handleTypeChange = async (event: Event) => {
+    const value =
+      event.currentTarget instanceof HTMLSelectElement ? event.currentTarget.value : "goal";
+    const nextType = value === "win" ? "win" : "goal";
+    setType(nextType);
+    setSubmitError(null);
+    setSubmitSuccess(null);
+
+    const file = selectedFile();
+    if (!file) return;
+
+    try {
+      const validation = await validateSoundUpload(file, nextType);
+      setPreviewDurationMs(validation.durationMs);
+    } catch (error) {
+      setPreviewDurationMs(null);
+      setSubmitError(
+        error instanceof Error ? error.message : "Could not validate the selected file."
+      );
+    }
+  };
+
+  const resetForm = () => {
+    setName("");
+    setSelectedFile(null);
+    setSubmitError(null);
+    setSubmitSuccess(null);
+    clearPreview();
+  };
+
+  const handleUpload = async (event: Event) => {
+    event.preventDefault();
+    const file = selectedFile();
+
+    if (!file) {
+      setSubmitError("Select an MP3 file before uploading.");
+      return;
+    }
+
+    if (!name().trim()) {
+      setSubmitError("Enter a display name before uploading.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+    setSubmitSuccess(null);
+
+    try {
+      await createSoundAsset({
+        file,
+        name: name().trim(),
+        type: type(),
+      });
+      await refetch();
+      resetForm();
+      setSubmitSuccess("Sound uploaded successfully.");
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : "Could not upload the sound.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const toggleStatus = async (id: string, currentStatus: "ready" | "disabled") => {
+    setUpdatingIds((ids) => [...ids, id]);
+
+    try {
+      await updateSoundAssetStatus(id, currentStatus === "ready" ? "disabled" : "ready");
+      await refetch();
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : "Could not update the sound status.");
+    } finally {
+      setUpdatingIds((ids) => ids.filter((value) => value !== id));
+    }
+  };
+
+  return (
+    <HomeShell>
+      <Switch>
+        <Match when={profile.loading}>
+          <div class="flex min-h-[40vh] items-center justify-center">
+            <Spinner />
+          </div>
+        </Match>
+        <Match when={!profile()}>
+          <div class="alert alert-error">
+            <span>Could not load your profile.</span>
+          </div>
+        </Match>
+        <Match when={!profile()?.is_admin}>
+          <div class="alert alert-warning">
+            <span>Only admins can manage public goal and win sounds.</span>
+          </div>
+        </Match>
+        <Match when={true}>
+          <section class="mx-auto flex w-full max-w-6xl flex-col gap-6">
+            <div class="card card-border border-base-300 bg-base-100 shadow-sm">
+              <div class="card-body gap-5">
+                <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                  <div>
+                    <p class="text-base-content/60 text-xs font-semibold tracking-[0.24em] uppercase">
+                      Admin
+                    </p>
+                    <h1 class="card-title text-2xl">Public sound library</h1>
+                    <p class="text-base-content/70 max-w-2xl text-sm">
+                      Manage the shared goal and win sound pools stored in Supabase Storage.
+                    </p>
+                  </div>
+                  <div class="text-base-content/70 flex items-center gap-2 text-sm font-medium">
+                    <AudioLines class="h-4 w-4" />
+                    <span>MP3 only</span>
+                    <span class="opacity-50">•</span>
+                    <span>2 MB max</span>
+                    <span class="opacity-50">•</span>
+                    <span>{typeLimitLabel()}</span>
+                  </div>
+                </div>
+
+                <form
+                  class="grid gap-6 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]"
+                  onSubmit={(event) => void handleUpload(event)}
+                >
+                  <div class="rounded-box bg-base-200 flex flex-col gap-4 p-4">
+                    <div class="grid gap-4 sm:grid-cols-2">
+                      <fieldset class="fieldset">
+                        <legend class="fieldset-legend">Sound type</legend>
+                        <select
+                          class="select select-bordered w-full"
+                          value={type()}
+                          onChange={(event) => void handleTypeChange(event)}
+                        >
+                          <option value="goal">Goal</option>
+                          <option value="win">Win</option>
+                        </select>
+                      </fieldset>
+
+                      <fieldset class="fieldset">
+                        <legend class="fieldset-legend">Display name</legend>
+                        <input
+                          class="input input-bordered w-full"
+                          maxLength={80}
+                          onInput={(event) => setName(event.currentTarget.value)}
+                          placeholder={type() === "goal" ? "Crowd pop" : "Final whistle"}
+                          value={name()}
+                        />
+                      </fieldset>
+                    </div>
+
+                    <fieldset class="fieldset">
+                      <legend class="fieldset-legend">MP3 file</legend>
+                      <input
+                        accept=".mp3,audio/mpeg"
+                        class="file-input file-input-bordered w-full"
+                        onChange={(event) => void handleFileChange(event)}
+                        type="file"
+                      />
+                    </fieldset>
+
+                    <div class="text-base-content/70 grid gap-2 text-sm sm:grid-cols-3">
+                      <div class="rounded-box bg-base-100 p-3">
+                        <div class="font-semibold">Type</div>
+                        <div class="capitalize">{type()}</div>
+                      </div>
+                      <div class="rounded-box bg-base-100 p-3">
+                        <div class="font-semibold">Limit</div>
+                        <div>{typeLimitLabel()}</div>
+                      </div>
+                      <div class="rounded-box bg-base-100 p-3">
+                        <div class="font-semibold">Max size</div>
+                        <div>2.00 MB</div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="rounded-box bg-base-200 flex flex-col gap-4 p-4">
+                    <div class="flex items-center justify-between gap-3">
+                      <div>
+                        <h2 class="text-lg font-semibold">Preview</h2>
+                        <p class="text-base-content/70 text-sm">
+                          Validation runs in the browser before anything is uploaded.
+                        </p>
+                      </div>
+                      <div class="badge badge-outline">
+                        {selectedFile() ? "Ready to review" : "No file selected"}
+                      </div>
+                    </div>
+
+                    <Show
+                      when={previewUrl()}
+                      fallback={
+                        <div class="border-base-300 rounded-box bg-base-100 text-base-content/70 flex min-h-36 items-center justify-center border border-dashed text-sm">
+                          Choose an MP3 file to preview it here.
+                        </div>
+                      }
+                    >
+                      {(url) => (
+                        <div class="rounded-box bg-base-100 flex flex-col gap-4 p-4">
+                          <audio class="w-full" controls preload="metadata" src={url()} />
+                          <div class="grid gap-3 sm:grid-cols-3">
+                            <div>
+                              <div class="text-base-content/60 text-xs font-semibold uppercase">
+                                File
+                              </div>
+                              <div class="truncate text-sm font-medium">{selectedFile()?.name}</div>
+                            </div>
+                            <div>
+                              <div class="text-base-content/60 text-xs font-semibold uppercase">
+                                Size
+                              </div>
+                              <div class="text-sm font-medium">
+                                {selectedFile() ? formatBytes(selectedFile()!.size) : "n/a"}
+                              </div>
+                            </div>
+                            <div>
+                              <div class="text-base-content/60 text-xs font-semibold uppercase">
+                                Duration
+                              </div>
+                              <div class="text-sm font-medium">
+                                {previewDurationMs() !== null
+                                  ? formatDuration(previewDurationMs()!)
+                                  : "Pending validation"}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                    </Show>
+
+                    <Show when={submitError()}>
+                      {(message) => (
+                        <div class="alert alert-error">
+                          <span>{message()}</span>
+                        </div>
+                      )}
+                    </Show>
+
+                    <Show when={submitSuccess()}>
+                      {(message) => (
+                        <div class="alert alert-success">
+                          <span>{message()}</span>
+                        </div>
+                      )}
+                    </Show>
+
+                    <div class="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                      <button class="btn btn-ghost" onClick={() => resetForm()} type="button">
+                        Clear
+                      </button>
+                      <button class="btn btn-primary gap-2" disabled={isSubmitting()} type="submit">
+                        <Upload class="h-4 w-4" />
+                        {isSubmitting() ? "Uploading..." : "Upload sound"}
+                      </button>
+                    </div>
+                  </div>
+                </form>
+              </div>
+            </div>
+
+            <div class="card card-border border-base-300 bg-base-100 shadow-sm">
+              <div class="card-body gap-4">
+                <div class="flex items-center justify-between gap-3">
+                  <div>
+                    <h2 class="card-title text-2xl">Existing sounds</h2>
+                    <p class="text-base-content/70 text-sm">
+                      Ready sounds are eligible for playback. Disabled sounds stay in the library
+                      but are skipped.
+                    </p>
+                  </div>
+                  <button class="btn btn-ghost btn-sm" onClick={() => void refetch()} type="button">
+                    Refresh
+                  </button>
+                </div>
+
+                <Show
+                  when={soundAssets()}
+                  fallback={
+                    <div class="flex min-h-32 items-center justify-center">
+                      <Spinner />
+                    </div>
+                  }
+                >
+                  {(assets) => (
+                    <div class="grid gap-4">
+                      <For each={assets()}>
+                        {(asset) => {
+                          const isUpdating = () => updatingIds().includes(asset.id);
+                          return (
+                            <div class="border-base-300 rounded-box grid gap-4 border p-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+                              <div class="grid gap-4">
+                                <div class="flex flex-wrap items-center gap-2">
+                                  <h3 class="text-lg font-semibold">{asset.name}</h3>
+                                  <span
+                                    class={`badge ${asset.type === "goal" ? "badge-primary" : "badge-secondary"} badge-outline capitalize`}
+                                  >
+                                    {asset.type}
+                                  </span>
+                                  <span
+                                    class={`badge ${asset.status === "ready" ? "badge-success" : "badge-warning"} capitalize`}
+                                  >
+                                    {asset.status}
+                                  </span>
+                                  <Show when={asset.isDefault}>
+                                    <span class="badge badge-outline">Default</span>
+                                  </Show>
+                                </div>
+
+                                <div class="text-base-content/70 grid gap-2 text-sm sm:grid-cols-3">
+                                  <div>
+                                    <div class="text-base-content/60 text-xs font-semibold uppercase">
+                                      Duration
+                                    </div>
+                                    <div>{formatDuration(asset.durationMs)}</div>
+                                  </div>
+                                  <div>
+                                    <div class="text-base-content/60 text-xs font-semibold uppercase">
+                                      Size
+                                    </div>
+                                    <div>{formatBytes(asset.sizeBytes)}</div>
+                                  </div>
+                                  <div>
+                                    <div class="text-base-content/60 text-xs font-semibold uppercase">
+                                      Source
+                                    </div>
+                                    <div class="truncate">{asset.storagePath}</div>
+                                  </div>
+                                </div>
+
+                                <audio class="w-full" controls preload="metadata" src={asset.url} />
+                              </div>
+
+                              <div class="flex justify-end">
+                                <button
+                                  class={`btn ${asset.status === "ready" ? "btn-soft btn-error" : "btn-outline"} gap-2`}
+                                  disabled={isUpdating()}
+                                  onClick={() => void toggleStatus(asset.id, asset.status)}
+                                  type="button"
+                                >
+                                  {asset.status === "ready" ? (
+                                    <VolumeX class="h-4 w-4" />
+                                  ) : (
+                                    <Volume2 class="h-4 w-4" />
+                                  )}
+                                  {isUpdating()
+                                    ? "Saving..."
+                                    : asset.status === "ready"
+                                      ? "Disable"
+                                      : "Enable"}
+                                </button>
+                              </div>
+                            </div>
+                          );
+                        }}
+                      </For>
+                    </div>
+                  )}
+                </Show>
+              </div>
+            </div>
+          </section>
+        </Match>
+      </Switch>
+    </HomeShell>
+  );
+}

--- a/src/components/sounds/SoundsPage.tsx
+++ b/src/components/sounds/SoundsPage.tsx
@@ -20,6 +20,9 @@ import {
   validateSoundUpload,
 } from "~/service/soundService.ts";
 
+const EMPTY_CAPTIONS_TRACK =
+  "data:text/vtt;charset=utf-8,WEBVTT%0A%0A00:00:00.000%20--%3E%2000:00:00.001%0A%20";
+
 function formatBytes(sizeBytes: number) {
   if (sizeBytes < 1024) return `${sizeBytes} B`;
   if (sizeBytes < 1024 * 1024) return `${(sizeBytes / 1024).toFixed(1)} KB`;
@@ -48,6 +51,18 @@ export default function SoundsPage() {
   const [updatingIds, setUpdatingIds] = createSignal<string[]>([]);
 
   const typeLimitLabel = createMemo(() => (type() === "goal" ? "Max 5s" : "Max 10s"));
+  const selectedFileSizeLabel = createMemo(() => {
+    const file = selectedFile();
+    return file ? formatBytes(file.size) : "n/a";
+  });
+  const previewDurationLabel = createMemo(() => {
+    const durationMs = previewDurationMs();
+    if (durationMs === null) {
+      return "Pending validation";
+    }
+
+    return formatDuration(durationMs);
+  });
 
   const clearPreview = () => {
     const url = previewUrl();
@@ -285,7 +300,15 @@ export default function SoundsPage() {
                     >
                       {(url) => (
                         <div class="rounded-box bg-base-100 flex flex-col gap-4 p-4">
-                          <audio class="w-full" controls preload="metadata" src={url()} />
+                          <audio class="w-full" controls preload="metadata" src={url()}>
+                            <track
+                              default
+                              kind="captions"
+                              label="No captions available"
+                              src={EMPTY_CAPTIONS_TRACK}
+                              srclang="en"
+                            />
+                          </audio>
                           <div class="grid gap-3 sm:grid-cols-3">
                             <div>
                               <div class="text-base-content/60 text-xs font-semibold uppercase">
@@ -297,19 +320,13 @@ export default function SoundsPage() {
                               <div class="text-base-content/60 text-xs font-semibold uppercase">
                                 Size
                               </div>
-                              <div class="text-sm font-medium">
-                                {selectedFile() ? formatBytes(selectedFile()!.size) : "n/a"}
-                              </div>
+                              <div class="text-sm font-medium">{selectedFileSizeLabel()}</div>
                             </div>
                             <div>
                               <div class="text-base-content/60 text-xs font-semibold uppercase">
                                 Duration
                               </div>
-                              <div class="text-sm font-medium">
-                                {previewDurationMs() !== null
-                                  ? formatDuration(previewDurationMs()!)
-                                  : "Pending validation"}
-                              </div>
+                              <div class="text-sm font-medium">{previewDurationLabel()}</div>
                             </div>
                           </div>
                         </div>
@@ -356,7 +373,7 @@ export default function SoundsPage() {
                       but are skipped.
                     </p>
                   </div>
-                  <button class="btn btn-ghost btn-sm" onClick={() => void refetch()} type="button">
+                  <button class="btn btn-ghost btn-sm" onClick={refetch} type="button">
                     Refresh
                   </button>
                 </div>
@@ -415,7 +432,15 @@ export default function SoundsPage() {
                                   </div>
                                 </div>
 
-                                <audio class="w-full" controls preload="metadata" src={asset.url} />
+                                <audio class="w-full" controls preload="metadata" src={asset.url}>
+                                  <track
+                                    default
+                                    kind="captions"
+                                    label="No captions available"
+                                    src={EMPTY_CAPTIONS_TRACK}
+                                    srclang="en"
+                                  />
+                                </audio>
                               </div>
 
                               <div class="flex justify-end">

--- a/src/components/sounds/SoundsPage.tsx
+++ b/src/components/sounds/SoundsPage.tsx
@@ -391,6 +391,14 @@ export default function SoundsPage() {
                       <For each={assets()}>
                         {(asset) => {
                           const isUpdating = () => updatingIds().includes(asset.id);
+                          const toggleStatusLabel = () => {
+                            if (isUpdating()) {
+                              return "Saving...";
+                            }
+
+                            return asset.status === "ready" ? "Disable" : "Enable";
+                          };
+
                           return (
                             <div class="border-base-300 rounded-box grid gap-4 border p-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
                               <div class="grid gap-4">
@@ -455,11 +463,7 @@ export default function SoundsPage() {
                                   ) : (
                                     <Volume2 class="h-4 w-4" />
                                   )}
-                                  {isUpdating()
-                                    ? "Saving..."
-                                    : asset.status === "ready"
-                                      ? "Disable"
-                                      : "Enable"}
+                                  {toggleStatusLabel()}
                                 </button>
                               </div>
                             </div>

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -51,4 +51,8 @@ export const routes = [
     path: "/leaderboard",
     component: lazy(() => import("../components/leaderboard/LeaderboardPage.tsx")),
   },
+  {
+    path: "/sounds",
+    component: lazy(() => import("../components/sounds/SoundsPage.tsx")),
+  },
 ];

--- a/src/service/profileService.ts
+++ b/src/service/profileService.ts
@@ -1,0 +1,39 @@
+import { supabase } from "./supabaseService";
+import type { Tables } from "~/types/database";
+
+export type Profile = Tables<"profiles">;
+
+export async function getCurrentProfile(): Promise<Profile | null> {
+  const client = supabase;
+  if (!client) return null;
+  const {
+    data: { user },
+    error: userError,
+  } = await client.auth.getUser();
+
+  if (userError) {
+    console.error("Error fetching current auth user:", userError);
+    throw new Error(userError.message);
+  }
+
+  if (!user) return null;
+
+  const { data, error } = await client
+    .from("profiles")
+    .select("*")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (error) {
+    console.error("Error fetching current profile:", error);
+    throw new Error(error.message);
+  }
+
+  return data;
+}
+
+export async function isCurrentUserAdmin() {
+  if (!supabase) return false;
+  const profile = await getCurrentProfile();
+  return profile?.is_admin ?? false;
+}

--- a/src/service/soundService.ts
+++ b/src/service/soundService.ts
@@ -1,8 +1,43 @@
 import { createSignal } from "solid-js";
+import { requireSupabase, supabase } from "./supabaseService";
+import type { Tables, TablesInsert } from "~/types/database";
 
 export type SoundType = "goal" | "no-goal" | "win";
+export type ManagedSoundType = Exclude<SoundType, "no-goal">;
+export type SoundStatus = Tables<"sound_assets">["status"];
+type SoundAssetRow = Tables<"sound_assets">;
 
 const MUTE_STORAGE_KEY = "foosball-muted";
+const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024;
+const MAX_DURATION_MS: Record<ManagedSoundType, number> = {
+  goal: 5_000,
+  win: 10_000,
+};
+const NO_GOAL_SOUND_TOTAL = 13;
+
+export interface SoundAsset {
+  checksum: string | null;
+  contentType: string;
+  createdAt: string;
+  durationMs: number;
+  id: string;
+  isDefault: boolean;
+  metadata: SoundAssetRow["metadata"];
+  name: string;
+  sizeBytes: number;
+  status: SoundStatus;
+  storageBucket: string;
+  storagePath: string;
+  type: ManagedSoundType;
+  uploadedBy: string | null;
+  url: string;
+}
+
+export interface SoundUploadValidationResult {
+  durationMs: number;
+  fileExtension: string;
+  sizeBytes: number;
+}
 
 function loadMuteState(): boolean {
   try {
@@ -13,12 +48,19 @@ function loadMuteState(): boolean {
 }
 
 const [isMuted, setIsMuted] = createSignal(loadMuteState());
+const [loadedSoundAssets, setLoadedSoundAssets] = createSignal<SoundAsset[]>([]);
+const [soundAssetsLoaded, setSoundAssetsLoaded] = createSignal(false);
 
-export { isMuted };
+const recentGoalIds: string[] = [];
+const recentNoGoalIndices: number[] = [];
+const preloadedAudio = new Map<string, HTMLAudioElement>();
+
+export { isMuted, soundAssetsLoaded };
 
 export function toggleMute() {
   const next = !isMuted();
   setIsMuted(next);
+
   try {
     localStorage.setItem(MUTE_STORAGE_KEY, String(next));
   } catch {
@@ -26,69 +68,297 @@ export function toggleMute() {
   }
 }
 
-class SoundService {
-  // Keep track of the last 5 picks per sound type (not needed for "win").
-  private readonly recentPicks: Record<"goal" | "no-goal", number[]> = {
-    goal: [],
-    "no-goal": [],
+function randomIndex(max: number) {
+  const array = new Uint32Array(1);
+  crypto.getRandomValues(array);
+  return array[0] % max;
+}
+
+function mapSoundAsset(row: SoundAssetRow): SoundAsset {
+  const url =
+    supabase?.storage.from(row.storage_bucket).getPublicUrl(row.storage_path).data.publicUrl ?? "";
+
+  return {
+    checksum: row.checksum,
+    contentType: row.content_type,
+    createdAt: row.created_at,
+    durationMs: row.duration_ms,
+    id: row.id,
+    isDefault: row.is_default,
+    metadata: row.metadata,
+    name: row.name,
+    sizeBytes: row.size_bytes,
+    status: row.status,
+    storageBucket: row.storage_bucket,
+    storagePath: row.storage_path,
+    type: row.type,
+    uploadedBy: row.uploaded_by,
+    url,
   };
+}
 
-  // Total number of sounds available for each type.
-  private readonly totals: Record<SoundType, number>;
+function primeAudio(url: string) {
+  if (!url || preloadedAudio.has(url)) return;
 
-  constructor(totals: Record<SoundType, number>) {
-    this.totals = totals;
+  const audio = new Audio(url);
+  audio.preload = "auto";
+  audio.load();
+  preloadedAudio.set(url, audio);
+}
+
+function playAudioUrl(url: string) {
+  if (!url) return;
+
+  const cached = preloadedAudio.get(url);
+  const audio = cached ? (cached.cloneNode(true) as HTMLAudioElement) : new Audio(url);
+  void audio.play().catch((error) => {
+    console.error("Failed to play sound:", error);
+  });
+}
+
+function getLocalNoGoalPath() {
+  let available: number[] = [];
+
+  for (let index = 0; index < NO_GOAL_SOUND_TOTAL; index += 1) {
+    if (!recentNoGoalIndices.includes(index)) {
+      available.push(index);
+    }
   }
 
-  getSoundPath(type: SoundType): string {
-    if (type === "win") {
-      // Always play the first "win" sound (or random if multiple exist)
-      return `/audio/win/win-1.mp3`;
-    }
+  if (available.length === 0) {
+    available = Array.from({ length: NO_GOAL_SOUND_TOTAL }, (_, index) => index);
+  }
 
-    const total = this.totals[type];
+  const chosenIndex = available[randomIndex(available.length)];
+  recentNoGoalIndices.push(chosenIndex);
 
-    // Build list of indices not in the recent picks.
-    let available: number[] = [];
-    for (let i = 0; i < total; i++) {
-      if (!this.recentPicks[type].includes(i)) {
-        available.push(i);
-      }
-    }
+  if (recentNoGoalIndices.length > 5) {
+    recentNoGoalIndices.shift();
+  }
 
-    // If all indices have been used recently, allow all.
-    if (available.length === 0) {
-      available = Array.from({ length: total }, (_, i) => i);
-    }
+  return `/audio/no-goal/no-goal-${chosenIndex}.mp3`;
+}
 
-    // Choose a random index from available ones using a CSPRNG.
-    const array = new Uint32Array(1);
-    crypto.getRandomValues(array);
-    const chosenIndex = available[array[0] % available.length];
+function pickGoalSound(pool: SoundAsset[]) {
+  let available = pool.filter((asset) => !recentGoalIds.includes(asset.id));
 
-    // Update recent picks (max last 5).
-    this.recentPicks[type].push(chosenIndex);
-    if (this.recentPicks[type].length > 5) {
-      this.recentPicks[type].shift();
-    }
+  if (available.length === 0) {
+    available = pool;
+  }
 
-    return `/audio/${type}/${type}-${chosenIndex}.mp3`;
+  const chosen = available[randomIndex(available.length)];
+  recentGoalIds.push(chosen.id);
+
+  if (recentGoalIds.length > 5) {
+    recentGoalIds.shift();
+  }
+
+  return chosen;
+}
+
+async function decodeDurationMs(file: File) {
+  const AudioContextCtor = globalThis.AudioContext;
+  if (!AudioContextCtor) {
+    throw new Error("AudioContext is not available.");
+  }
+
+  const audioContext = new AudioContextCtor();
+
+  try {
+    const buffer = await file.arrayBuffer();
+    const audioBuffer = await audioContext.decodeAudioData(buffer.slice(0));
+    return Math.round(audioBuffer.duration * 1000);
+  } finally {
+    await audioContext.close();
   }
 }
 
-// Create a default instance.
-const soundService = new SoundService({
-  goal: 22,
-  "no-goal": 13,
-  win: 1, // Set to the number of available "win" sounds
-});
+async function sha256(file: File) {
+  const buffer = await file.arrayBuffer();
+  const digest = await crypto.subtle.digest("SHA-256", buffer);
+  return [...new Uint8Array(digest)].map((value) => value.toString(16).padStart(2, "0")).join("");
+}
 
-export default soundService;
+export function getLoadedSoundAssets() {
+  return loadedSoundAssets();
+}
+
+export async function listSoundAssets(options?: {
+  includeDisabled?: boolean;
+  type?: ManagedSoundType;
+}) {
+  const client = requireSupabase();
+  const includeDisabled = options?.includeDisabled ?? false;
+
+  let query = client
+    .from("sound_assets")
+    .select("*")
+    .order("type", { ascending: true })
+    .order("is_default", { ascending: false })
+    .order("created_at", { ascending: true });
+
+  if (!includeDisabled) {
+    query = query.eq("status", "ready");
+  }
+
+  if (options?.type) {
+    query = query.eq("type", options.type);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error("Error listing sound assets:", error);
+    throw new Error(error.message);
+  }
+
+  return (data ?? []).map(mapSoundAsset);
+}
+
+export async function refreshSoundAssets() {
+  if (!supabase) {
+    setLoadedSoundAssets([]);
+    setSoundAssetsLoaded(true);
+    return [];
+  }
+
+  try {
+    const assets = await listSoundAssets();
+    assets.forEach((asset) => primeAudio(asset.url));
+    setLoadedSoundAssets(assets);
+    return assets;
+  } finally {
+    setSoundAssetsLoaded(true);
+  }
+}
+
+export async function validateSoundUpload(file: File, type: ManagedSoundType) {
+  const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
+
+  if (file.type !== "audio/mpeg") {
+    throw new Error("Only MP3 files with MIME type audio/mpeg are supported.");
+  }
+
+  if (extension !== "mp3") {
+    throw new Error("Only .mp3 files are supported.");
+  }
+
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    throw new Error("Files larger than 2 MB are not allowed.");
+  }
+
+  let durationMs: number;
+
+  try {
+    durationMs = await decodeDurationMs(file);
+  } catch (error) {
+    console.error("Failed to decode uploaded audio:", error);
+    throw new Error("Could not decode the selected MP3 file.");
+  }
+
+  if (durationMs > MAX_DURATION_MS[type]) {
+    const seconds = (MAX_DURATION_MS[type] / 1000).toFixed(0);
+    throw new Error(
+      `${type === "goal" ? "Goal" : "Win"} sounds must be ${seconds} seconds or shorter.`
+    );
+  }
+
+  return {
+    durationMs,
+    fileExtension: extension,
+    sizeBytes: file.size,
+  } satisfies SoundUploadValidationResult;
+}
+
+export async function createSoundAsset(params: {
+  file: File;
+  name: string;
+  type: ManagedSoundType;
+}) {
+  const client = requireSupabase();
+  const validation = await validateSoundUpload(params.file, params.type);
+  const checksum = await sha256(params.file);
+  const soundId = crypto.randomUUID();
+  const storagePath = `ready/${soundId}/${checksum}.mp3`;
+
+  const { error: uploadError } = await client.storage
+    .from("sounds")
+    .upload(storagePath, params.file, {
+      contentType: "audio/mpeg",
+      upsert: false,
+    });
+
+  if (uploadError) {
+    console.error("Error uploading sound asset:", uploadError);
+    throw new Error(uploadError.message);
+  }
+
+  const row: TablesInsert<"sound_assets"> = {
+    checksum,
+    content_type: "audio/mpeg",
+    duration_ms: validation.durationMs,
+    id: soundId,
+    metadata: {
+      original_filename: params.file.name,
+      uploaded_via: "web",
+    },
+    name: params.name.trim(),
+    size_bytes: validation.sizeBytes,
+    status: "ready",
+    storage_bucket: "sounds",
+    storage_path: storagePath,
+    type: params.type,
+  };
+
+  const { data, error } = await client.from("sound_assets").insert(row).select().single();
+
+  if (error) {
+    await client.storage.from("sounds").remove([storagePath]);
+    console.error("Error inserting sound asset metadata:", error);
+    throw new Error(error.message);
+  }
+
+  const asset = mapSoundAsset(data);
+  primeAudio(asset.url);
+  await refreshSoundAssets();
+  return asset;
+}
+
+export async function updateSoundAssetStatus(id: string, status: SoundStatus) {
+  const client = requireSupabase();
+  const { data, error } = await client
+    .from("sound_assets")
+    .update({ status })
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Error updating sound asset status:", error);
+    throw new Error(error.message);
+  }
+
+  await refreshSoundAssets();
+  return mapSoundAsset(data);
+}
 
 export function playSound(type: SoundType) {
   if (isMuted()) return;
-  const soundUrl = soundService.getSoundPath(type);
-  console.log("playing sound url", soundUrl);
-  const audio = new Audio(soundUrl);
-  audio.play().then(() => console.log("Audio played:", soundUrl));
+
+  if (type === "no-goal") {
+    playAudioUrl(getLocalNoGoalPath());
+    return;
+  }
+
+  const pool = loadedSoundAssets().filter(
+    (asset) => asset.type === type && asset.status === "ready"
+  );
+
+  if (pool.length === 0) {
+    console.warn(`No ready ${type} sounds are loaded.`);
+    return;
+  }
+
+  const selectedAsset = type === "goal" ? pickGoalSound(pool) : pool[randomIndex(pool.length)];
+  playAudioUrl(selectedAsset.url);
 }

--- a/src/service/soundService.ts
+++ b/src/service/soundService.ts
@@ -9,6 +9,7 @@ type SoundAssetRow = Tables<"sound_assets">;
 
 const MUTE_STORAGE_KEY = "foosball-muted";
 const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024;
+const ACCEPTED_MP3_MIME_TYPES = new Set(["", "audio/mpeg", "audio/mp3", "audio/x-mpeg"]);
 const MAX_DURATION_MS: Record<ManagedSoundType, number> = {
   goal: 5_000,
   win: 10_000,
@@ -264,12 +265,12 @@ export async function refreshSoundAssets() {
 export async function validateSoundUpload(file: File, type: ManagedSoundType) {
   const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
 
-  if (file.type !== "audio/mpeg") {
-    throw new Error("Only MP3 files with MIME type audio/mpeg are supported.");
-  }
-
   if (extension !== "mp3") {
     throw new Error("Only .mp3 files are supported.");
+  }
+
+  if (!ACCEPTED_MP3_MIME_TYPES.has(file.type)) {
+    throw new Error("Only MP3 files are supported.");
   }
 
   if (file.size > MAX_FILE_SIZE_BYTES) {

--- a/src/service/soundService.ts
+++ b/src/service/soundService.ts
@@ -13,6 +13,7 @@ const MAX_DURATION_MS: Record<ManagedSoundType, number> = {
   goal: 5_000,
   win: 10_000,
 };
+const LOCAL_FALLBACK_GOAL_TOTAL = 23;
 const NO_GOAL_SOUND_TOTAL = 13;
 
 export interface SoundAsset {
@@ -52,6 +53,7 @@ const [loadedSoundAssets, setLoadedSoundAssets] = createSignal<SoundAsset[]>([])
 const [soundAssetsLoaded, setSoundAssetsLoaded] = createSignal(false);
 
 const recentGoalIds: string[] = [];
+const recentLocalGoalIndices: number[] = [];
 const recentNoGoalIndices: number[] = [];
 const preloadedAudio = new Map<string, HTMLAudioElement>();
 
@@ -137,6 +139,33 @@ function getLocalNoGoalPath() {
   }
 
   return `/audio/no-goal/no-goal-${chosenIndex}.mp3`;
+}
+
+function getLocalGoalPath() {
+  let available: number[] = [];
+
+  for (let index = 0; index < LOCAL_FALLBACK_GOAL_TOTAL; index += 1) {
+    if (!recentLocalGoalIndices.includes(index)) {
+      available.push(index);
+    }
+  }
+
+  if (available.length === 0) {
+    available = Array.from({ length: LOCAL_FALLBACK_GOAL_TOTAL }, (_, index) => index);
+  }
+
+  const chosenIndex = available[randomIndex(available.length)];
+  recentLocalGoalIndices.push(chosenIndex);
+
+  if (recentLocalGoalIndices.length > 5) {
+    recentLocalGoalIndices.shift();
+  }
+
+  return `/audio/goal/goal-${chosenIndex}.mp3`;
+}
+
+function getLocalWinPath() {
+  return "/audio/win/win-1.mp3";
 }
 
 function pickGoalSound(pool: SoundAsset[]) {
@@ -355,7 +384,9 @@ export function playSound(type: SoundType) {
   );
 
   if (pool.length === 0) {
-    console.warn(`No ready ${type} sounds are loaded.`);
+    const fallbackUrl = type === "goal" ? getLocalGoalPath() : getLocalWinPath();
+    console.warn(`No ready ${type} sounds are loaded. Falling back to bundled audio.`);
+    playAudioUrl(fallbackUrl);
     return;
   }
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -213,6 +213,57 @@ export type Database = {
         };
         Relationships: [];
       };
+      sound_assets: {
+        Row: {
+          checksum: string | null;
+          content_type: string;
+          created_at: string;
+          duration_ms: number;
+          id: string;
+          is_default: boolean;
+          metadata: Json;
+          name: string;
+          size_bytes: number;
+          status: Database["public"]["Enums"]["sound_status"];
+          storage_bucket: string;
+          storage_path: string;
+          type: Database["public"]["Enums"]["sound_type"];
+          uploaded_by: string | null;
+        };
+        Insert: {
+          checksum?: string | null;
+          content_type?: string;
+          created_at?: string;
+          duration_ms: number;
+          id?: string;
+          is_default?: boolean;
+          metadata?: Json;
+          name: string;
+          size_bytes: number;
+          status?: Database["public"]["Enums"]["sound_status"];
+          storage_bucket?: string;
+          storage_path: string;
+          type: Database["public"]["Enums"]["sound_type"];
+          uploaded_by?: string | null;
+        };
+        Update: {
+          checksum?: string | null;
+          content_type?: string;
+          created_at?: string;
+          duration_ms?: number;
+          id?: string;
+          is_default?: boolean;
+          metadata?: Json;
+          name?: string;
+          size_bytes?: number;
+          status?: Database["public"]["Enums"]["sound_status"];
+          storage_bucket?: string;
+          storage_path?: string;
+          type?: Database["public"]["Enums"]["sound_type"];
+          uploaded_by?: string | null;
+        };
+        Relationships: [];
+      };
       team_members: {
         Row: {
           player_id: number;
@@ -333,6 +384,8 @@ export type Database = {
       match_event_source: "sensor" | "web" | "system";
       match_event_status: "valid" | "invalid" | "removed";
       match_event_type: "goal_detected" | "goal_removed" | "score_reset" | "manual_correction";
+      sound_status: "ready" | "disabled";
+      sound_type: "goal" | "win";
       team_type: "player" | "team";
     };
     CompositeTypes: {
@@ -462,6 +515,8 @@ export const Constants = {
       match_event_source: ["sensor", "web", "system"],
       match_event_status: ["valid", "invalid", "removed"],
       match_event_type: ["goal_detected", "goal_removed", "score_reset", "manual_correction"],
+      sound_status: ["ready", "disabled"],
+      sound_type: ["goal", "win"],
       team_type: ["player", "team"],
     },
   },

--- a/supabase/migrations/20260603084516_sound-assets.sql
+++ b/supabase/migrations/20260603084516_sound-assets.sql
@@ -33,6 +33,7 @@ CREATE INDEX sound_assets_status_default_idx ON public.sound_assets (status, is_
 ALTER TABLE public.sound_assets ENABLE ROW LEVEL SECURITY;
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON public.sound_assets TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.sound_assets TO service_role;
 
 CREATE POLICY "Authenticated users can view ready sounds" ON public.sound_assets
   FOR SELECT TO authenticated

--- a/supabase/migrations/20260603084516_sound-assets.sql
+++ b/supabase/migrations/20260603084516_sound-assets.sql
@@ -1,0 +1,69 @@
+CREATE TYPE public.sound_type AS ENUM ('goal', 'win');
+CREATE TYPE public.sound_status AS ENUM ('ready', 'disabled');
+
+CREATE TABLE public.sound_assets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  uploaded_by uuid DEFAULT auth.uid() REFERENCES auth.users(id) ON DELETE SET NULL,
+  type public.sound_type NOT NULL,
+  status public.sound_status NOT NULL DEFAULT 'ready',
+  name text NOT NULL,
+  storage_bucket text NOT NULL DEFAULT 'sounds',
+  storage_path text NOT NULL,
+  content_type text NOT NULL DEFAULT 'audio/mpeg',
+  size_bytes bigint NOT NULL,
+  duration_ms integer NOT NULL,
+  checksum text,
+  is_default boolean NOT NULL DEFAULT false,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT sound_assets_name_check CHECK (char_length(btrim(name)) > 0),
+  CONSTRAINT sound_assets_storage_path_key UNIQUE (storage_path),
+  CONSTRAINT sound_assets_content_type_check CHECK (content_type = 'audio/mpeg'),
+  CONSTRAINT sound_assets_size_check CHECK (size_bytes > 0 AND size_bytes <= 2097152),
+  CONSTRAINT sound_assets_duration_check CHECK (
+    is_default
+    OR (type = 'goal' AND duration_ms <= 5000)
+    OR (type = 'win' AND duration_ms <= 10000)
+  )
+);
+
+CREATE INDEX sound_assets_type_status_idx ON public.sound_assets (type, status);
+CREATE INDEX sound_assets_status_default_idx ON public.sound_assets (status, is_default);
+
+ALTER TABLE public.sound_assets ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.sound_assets TO authenticated;
+
+CREATE POLICY "Authenticated users can view ready sounds" ON public.sound_assets
+  FOR SELECT TO authenticated
+  USING (status = 'ready');
+
+CREATE POLICY "Admins can manage all sound assets" ON public.sound_assets
+  FOR ALL TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('sounds', 'sounds', true, 2097152, ARRAY['audio/mpeg'])
+ON CONFLICT (id) DO UPDATE
+SET
+  public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+CREATE POLICY "Authenticated users can read sound objects" ON storage.objects
+  FOR SELECT TO authenticated
+  USING (bucket_id = 'sounds');
+
+CREATE POLICY "Admins can upload sound objects" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'sounds' AND public.is_admin());
+
+CREATE POLICY "Admins can update sound objects" ON storage.objects
+  FOR UPDATE TO authenticated
+  USING (bucket_id = 'sounds' AND public.is_admin())
+  WITH CHECK (bucket_id = 'sounds' AND public.is_admin());
+
+CREATE POLICY "Admins can delete sound objects" ON storage.objects
+  FOR DELETE TO authenticated
+  USING (bucket_id = 'sounds' AND public.is_admin());


### PR DESCRIPTION
Closes #52

## Summary
- move public goal and win sounds to Supabase Storage and sound_assets metadata
- add local default sound seeding plus playback/service refactor for metadata-driven pools
- add an admin-only /sounds management screen and fix the authenticated login-page Playwright flow

## Verification
- pnpm local:reset
- pnpm db-types
- pnpm lint
- pnpm build
- pnpm auth:local
- pnpm proof:capture -- --name sounds-admin --route /sounds
- pnpm test:e2e:auth