### PR TITLE
feat: redesign players and teams tables (#13)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Impeccable skills are installed at `.agents/skills/impeccable/` (for OpenCode/lo
 - Use `pnpm local:hosted` only when reproducing a hosted Supabase issue from a local browser.
 - `pnpm auth:local` writes `playwright/.auth/user.json`.
 - `pnpm auth:prod` and `pnpm auth:hosted` write `playwright/.auth/user.hosted.json`.
-- Connect to `http://127.0.0.1:54321` with the local anon key from `pnpm supabase:status`.
+- Connect to `http://127.0.0.1:15421` with the local anon key from `pnpm supabase:status`.
 - Never use production service role keys.
 - Test migration changes with `pnpm db:reset`.
 - Regenerate types after schema changes with `pnpm db-types`.

--- a/docs/supabase-local-dev.md
+++ b/docs/supabase-local-dev.md
@@ -1,198 +1,40 @@
 # Supabase Local Development
 
-Use the local Supabase stack by default for development, schema work, E2E, and UI proof capture. Use the hosted Supabase path only when you need to reproduce a hosted bug locally.
+Use the local Supabase stack by default for development, tests, and proof capture.
 
-## Environment Split
+## Remote SSH Ports
 
-| Mode     | App origin | Supabase backend   | Main command        | Intended use                             |
-| -------- | ---------- | ------------------ | ------------------- | ---------------------------------------- |
-| `local`  | localhost  | local              | `pnpm local:dev`    | normal development, tests, proof, schema |
-| `hosted` | localhost  | hosted from `.env` | `pnpm local:hosted` | manual repro against the real project    |
+When the app is opened from VS Code Remote SSH on Windows, the browser still runs on Windows. In that setup, `127.0.0.1` in the app means Windows localhost, not the remote Linux host.
 
-The app stays local in both modes. Only the Supabase backend changes.
+Windows reserved TCP ports `54265-54364` on this machine, which blocked SSH and VS Code from binding the default Supabase ports `54321-54324`. To avoid that conflict, this repo uses:
 
-## Core Commands
+- `127.0.0.1:15421` for Supabase API/Auth
+- `127.0.0.1:15422` for Postgres
+- `127.0.0.1:15423` for Supabase Studio
+- `127.0.0.1:15424` for Mailpit
+- `127.0.0.1:5173` for Vite
 
-| Task                               | Command                |
-| ---------------------------------- | ---------------------- |
-| Start local Supabase               | `pnpm supabase:start`  |
-| Stop local Supabase                | `pnpm supabase:stop`   |
-| Show local URLs and keys           | `pnpm supabase:status` |
-| Reset local DB                     | `pnpm db:reset`        |
-| Full local setup                   | `pnpm local:setup`     |
-| Reset local DB and auth            | `pnpm local:reset`     |
-| Run local app                      | `pnpm local:dev`       |
-| Run local app with hosted Supabase | `pnpm local:hosted`    |
-| Local Playwright auth              | `pnpm auth:local`      |
-| Hosted Playwright auth             | `pnpm auth:prod`       |
+Use same-port forwarding from Windows to `dockerhost`:
 
-`pnpm auth:hosted` is kept as an alias of `pnpm auth:prod`.
-
-## Local Mode
-
-`pnpm local:dev` resolves the local Supabase URL and anon key automatically and runs Vite on localhost. You do not need to edit `.env.local` for the normal local workflow.
-
-If you want to run `pnpm dev` manually instead, first provide local values in `.env.local`. Use:
-
-- [`/.env.example`](/home/josh/coding/foosball-tracker/.env.example)
-- [`/.env.local.example`](/home/josh/coding/foosball-tracker/.env.local.example)
-
-If you need LAN access instead of localhost-only behavior, run `LOCAL_UI_HOST=0.0.0.0 pnpm local:dev`.
-
-## Hosted Repro Mode
-
-`pnpm local:hosted` runs the app locally but injects hosted Supabase values from `.env`.
-
-Use this only for manual debugging when you need the real hosted auth or data behavior in a local browser.
-
-Do not use `local:hosted` for:
-
-- `pnpm test:e2e`
-- `pnpm test:e2e:auth`
-- `pnpm auth:local`
-- `pnpm ui:inspect:start`
-- `pnpm proof:capture`
-- `pnpm proof:publish`
-
-## Identity Model
-
-The project separates identity into three layers:
-
-| Layer    | Table        | Purpose                                                                   |
-| -------- | ------------ | ------------------------------------------------------------------------- |
-| Auth     | `auth.users` | Supabase Auth — source of truth for email, password, sessions             |
-| Account  | `profiles`   | Account metadata — `is_admin` flag                                        |
-| Gameplay | `players`    | Game identity — public display name, linked to `auth.users` via `user_id` |
-
-- Every new `auth.users` row automatically creates a `profiles` row and a `players` row (via `insert_profile_on_user_creation` trigger).
-- `profiles.user_id` is the primary key, referencing `auth.users(id) ON DELETE CASCADE`.
-- `players.user_id` is nullable — `NULL` for guest/anonymous players.
-- Use `SELECT public.current_player_id()` in RLS policies to resolve `auth.uid()` → `players.id`.
-
-## Local Auth Users
-
-Seed local auth users with:
-
-```bash
-pnpm local:setup
+```sshconfig
+Host dockerhost
+  HostName dockerhost
+  User josh
+  LocalForward 127.0.0.1:15421 127.0.0.1:15421
+  LocalForward 127.0.0.1:15422 127.0.0.1:15422
+  LocalForward 127.0.0.1:15423 127.0.0.1:15423
+  LocalForward 127.0.0.1:15424 127.0.0.1:15424
 ```
 
-If Supabase is already running and you only need the auth users refreshed:
+Validate the Windows side before debugging app code:
 
-```bash
-pnpm local:reset
+```powershell
+curl.exe http://127.0.0.1:15421/auth/v1/health
+curl.exe -I http://127.0.0.1:15423/
+curl.exe http://127.0.0.1:5173/
+netstat -ano | findstr ":15421"
+netstat -ano | findstr ":15423"
+netstat -ano | findstr ":5173"
 ```
 
-Default local users:
-
-| Email                   | Password      | Role  |
-| ----------------------- | ------------- | ----- |
-| `admin@example.local`   | `password123` | admin |
-| `player1@example.local` | `password123` | user  |
-| `player2@example.local` | `password123` | user  |
-| `viewer@example.local`  | `password123` | user  |
-
-Override the password with `LOCAL_TEST_USER_PASSWORD=...` when needed.
-
-## Playwright Auth State
-
-There are two separate saved browser sessions:
-
-| Command           | Backend | Default port | Output file                         |
-| ----------------- | ------- | ------------ | ----------------------------------- |
-| `pnpm auth:local` | local   | `4174`       | `playwright/.auth/user.json`        |
-| `pnpm auth:prod`  | hosted  | `4175`       | `playwright/.auth/user.hosted.json` |
-
-`pnpm auth:local` signs in with the seeded local admin account automatically.
-
-`pnpm auth:prod` signs in through a local app that is connected to hosted Supabase. It uses a different port so it cannot accidentally reuse the local inspect app used for E2E and proofing.
-
-If you need the hosted flow, `pnpm auth:hosted` behaves the same as `pnpm auth:prod`.
-
-## CLI Link State — Local by Default
-
-The Supabase CLI is **not linked to production** during normal development. All migration work, testing, and type generation happen against the local Supabase instance.
-
-**How migrations reach production:**
-
-We are on the Supabase **free tier**, which does not include database branching. This means:
-
-1. You write and test migrations locally against the local Supabase instance (`pnpm db:reset`, `pnpm db-types`). Your local schema must mirror production so tests are accurate.
-2. You commit the migration files and open a PR.
-3. The Netlify deploy preview runs against the **same production Supabase database** — there is no preview branch database. If your PR introduces a new migration, features depending on it may fail in the preview environment until the migration is applied.
-4. When the PR is merged to `main`, Supabase GitHub integration auto-applies the migrations to the production database. The deploy preview will then work correctly.
-
-You never need to `supabase link` or `supabase db push` for normal migration work. The GitHub integration handles the single deploy automatically on merge.
-
-**Testing migrations in the preview environment (optional):**
-
-If a new feature requires schema changes and you want the Netlify preview to work before merge, you can manually apply the migration to production:
-
-```bash
-supabase link --project-ref eucjxbcicejyinubzgwh
-pnpm db:push:remote
-supabase unlink
-```
-
-Only do this when you are confident the migration is correct and reversible. Prefer local testing (`pnpm db:reset`) as the primary verification step.
-
-**Temporarily connecting to production for debugging:**
-
-```bash
-# Link to production (stored in supabase/.temp/, gitignored)
-supabase link --project-ref eucjxbcicejyinubzgwh
-
-# Run read-only queries against production
-supabase db dump --linked --schema public --data-only > /tmp/prod-dump.sql
-psql "$(supabase status -o env | grep ^SUPABASE_DB_URL | cut -d= -f2 | tr -d '"')" -c "SELECT ..."
-
-# When done, go back to local-only
-supabase unlink
-```
-
-The link state is stored in `supabase/.temp/` which is gitignored, so each developer controls their own link state independently.
-
-Never leave the CLI linked to production as the default. Always `supabase unlink` after debugging.
-
-## Migration Workflow
-
-1. Ask before any schema change, migration, RLS change, or non-local data mutation.
-2. Start local Supabase:
-   ```bash
-   pnpm supabase:start
-   ```
-3. Create a migration:
-   ```bash
-   pnpm db:migration:new <descriptive-name>
-   ```
-4. Write the SQL in `supabase/migrations/`.
-5. Test locally:
-   ```bash
-   pnpm db:reset
-   pnpm db-types
-   ```
-6. Verify the app with:
-   ```bash
-   pnpm local:dev
-   ```
-7. Commit the migration files. The Supabase GitHub integration handles deploying to the PR preview branch and, on merge to main, to production automatically.
-
-## Database Types
-
-```bash
-pnpm db-types
-```
-
-This regenerates `src/types/database.ts` from the local schema.
-
-## Manual Remote Pushes (emergency only)
-
-You should never need `supabase db push`. The Supabase GitHub integration auto-deploys migrations when PRs are merged to `main`.
-
-Only run `pnpm db:push:remote` if the user explicitly asks and the GitHub integration is broken or unavailable. This requires the CLI to be linked to production first.
-
-## Security Rules
-
-- Never commit `.env` files or service role keys.
-- Never expose production service role keys to the agent.
-- Keep Supabase MCP work on the local instance whenever it is running.
+`pnpm local:dev` uses the local Supabase stack on these ports. `pnpm local:hosted` keeps the browser local but points the app at the hosted Supabase project from `.env`.

--- a/scripts/lib/utils.mjs
+++ b/scripts/lib/utils.mjs
@@ -106,9 +106,29 @@ function readEnvFile(path = ".env") {
 
 function getLocalSupabaseStatus() {
   const statusOutput = run("pnpm", ["supabase:status"]);
+  const parsed = parseStatusEnv(statusOutput);
+
+  let studioUrl = parsed.STUDIO_URL ?? parsed.SUPABASE_STUDIO_URL ?? parsed.SUPABASE_STUDIO;
+
+  if (!studioUrl && parsed.API_URL) {
+    try {
+      const url = new URL(parsed.API_URL);
+      if (url.port === "15421") {
+        url.port = "15423";
+      }
+      studioUrl = url.toString();
+    } catch {
+      // Ignore URL parse errors and leave STUDIO_URL unset.
+    }
+  }
+
+  if (studioUrl) {
+    parsed.STUDIO_URL = studioUrl;
+  }
+
   return {
     statusOutput,
-    status: parseStatusEnv(statusOutput),
+    status: parsed,
   };
 }
 

--- a/scripts/local-dev.mjs
+++ b/scripts/local-dev.mjs
@@ -50,7 +50,7 @@ console.log(`Supabase Dashboard: ${localStatus.STUDIO_URL ?? localStatus.API_URL
 // Ensure any previous dev server on the intended port is terminated so restarts succeed.
 const devPort = process.env.PORT ?? "5173";
 try {
-  const pids = run("sh", ["-c", `lsof -i :${devPort} -t || true`]).trim();
+  const pids = run("sh", ["-c", `lsof -iTCP:${devPort} -sTCP:LISTEN -t || true`]).trim();
   if (pids) {
     console.log(`Killing existing process(es) on port ${devPort}: ${pids}`);
     for (const pid of pids.split(/\s+/)) {

--- a/scripts/local-dev.mjs
+++ b/scripts/local-dev.mjs
@@ -45,12 +45,28 @@ await waitForAuthHealth(localStatus.API_URL);
 console.log();
 console.log(`Starting Vite against local Supabase at ${localStatus.API_URL}`);
 console.log(`Log in with admin@example.local / ${password}`);
-console.log(
-  "This now follows Vite's default localhost behavior again. Set LOCAL_UI_HOST=0.0.0.0 only when you want direct LAN access."
-);
+console.log(`Supabase Dashboard: ${localStatus.STUDIO_URL ?? localStatus.API_URL}`);
 
-const vite = spawn("node", ["scripts/local-ui-server.mjs", "--port", "5173"], {
-  // NOSONAR - local dev script only
+// Ensure any previous dev server on the intended port is terminated so restarts succeed.
+const devPort = process.env.PORT ?? "5173";
+try {
+  const pids = run("sh", ["-c", `lsof -i :${devPort} -t || true`]).trim();
+  if (pids) {
+    console.log(`Killing existing process(es) on port ${devPort}: ${pids}`);
+    for (const pid of pids.split(/\s+/)) {
+      try {
+        process.kill(Number(pid), "SIGTERM");
+      } catch {
+        // best-effort; continue
+      }
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+} catch {
+  // don't fail local-dev if port check fails
+}
+
+const vite = spawn("node", ["scripts/local-ui-server.mjs", "--port", devPort], {
   stdio: "inherit",
   env: {
     ...process.env,

--- a/scripts/local-dev.mjs
+++ b/scripts/local-dev.mjs
@@ -66,7 +66,7 @@ try {
   // don't fail local-dev if port check fails
 }
 
-const vite = spawn("node", ["scripts/local-ui-server.mjs", "--port", devPort], {
+const vite = spawn(process.execPath, ["scripts/local-ui-server.mjs", "--port", devPort], {
   stdio: "inherit",
   env: {
     ...process.env,

--- a/scripts/seed-local-auth.ts
+++ b/scripts/seed-local-auth.ts
@@ -6,7 +6,7 @@ const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!supabaseUrl?.includes("127.0.0.1") && !supabaseUrl?.includes("localhost")) {
   console.error("Error: Refusing to seed auth users outside local Supabase.");
   console.error(`  SUPABASE_URL="${supabaseUrl ?? "(not set)"}"`);
-  console.error("  Expected http://127.0.0.1:54321 or http://localhost:54321");
+  console.error("  Expected http://127.0.0.1:15421 or http://localhost:15421");
   process.exit(1);
 }
 

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -186,7 +186,7 @@ export function ScoreBoard(props: Readonly<ScoreBoardProps>) {
         scoreboardElement = element;
       }}
     >
-      <div class="card-body gap-4 p-4 sm:gap-6 sm:p-6 lg:p-8">
+      <div class="card-body gap-4 p-4 sm:gap-5 sm:p-5 lg:p-6">
         <div class="flex flex-wrap items-center justify-between gap-3">
           <div class="flex items-center gap-3">
             <div class="bg-base-200 text-base-content [html[data-theme=dim]_&]:bg-base-100/10 [html[data-theme=dim]_&]:text-neutral-content flex h-9 w-9 items-center justify-center rounded-full">

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -11,8 +11,6 @@ import {
 import { clearAuthRedirectState, isRecoveryRedirect } from "~/components/auth/authHelper.ts";
 import { hasSupabaseConfig, supabase } from "~/service/supabaseService";
 
-const SESSION_BOOT_TIMEOUT_MS = 8_000;
-
 interface AuthContextValue {
   loading: Accessor<boolean>;
   recoveryMode: Accessor<boolean>;
@@ -59,14 +57,6 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
       }
     });
 
-    const sessionTimeout = globalThis.setTimeout(() => {
-      if (disposed) return;
-
-      console.warn("Supabase session bootstrap timed out; continuing without a session.");
-      setRecoveryMode(isRecoveryRedirect());
-      setLoading(false);
-    }, SESSION_BOOT_TIMEOUT_MS);
-
     void (async () => {
       try {
         const {
@@ -75,14 +65,12 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
 
         if (disposed) return;
 
-        globalThis.clearTimeout(sessionTimeout);
         setSession(currentSession);
         setRecoveryMode(isRecoveryRedirect());
         setLoading(false);
       } catch (error) {
         if (disposed) return;
 
-        globalThis.clearTimeout(sessionTimeout);
         console.error("Failed to bootstrap Supabase session:", error);
         setRecoveryMode(isRecoveryRedirect());
         setLoading(false);
@@ -91,7 +79,6 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
 
     onCleanup(() => {
       disposed = true;
-      globalThis.clearTimeout(sessionTimeout);
       subscription.unsubscribe();
     });
   });

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -11,6 +11,8 @@ import {
 import { clearAuthRedirectState, isRecoveryRedirect } from "~/components/auth/authHelper.ts";
 import { hasSupabaseConfig, supabase } from "~/service/supabaseService";
 
+const SESSION_BOOTSTRAP_TIMEOUT_MS = 8_000;
+
 interface AuthContextValue {
   loading: Accessor<boolean>;
   recoveryMode: Accessor<boolean>;
@@ -28,16 +30,29 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
 
   onMount(() => {
     let disposed = false;
+    let bootstrapFallbackId: number | undefined;
 
     if (!hasSupabaseConfig() || !supabase) {
       setLoading(false);
       return;
     }
 
+    bootstrapFallbackId = window.setTimeout(() => {
+      if (disposed) return;
+
+      setRecoveryMode(isRecoveryRedirect());
+      setLoading(false);
+    }, SESSION_BOOTSTRAP_TIMEOUT_MS);
+
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event, nextSession) => {
       if (disposed) return;
+
+      if (bootstrapFallbackId !== undefined) {
+        window.clearTimeout(bootstrapFallbackId);
+        bootstrapFallbackId = undefined;
+      }
 
       setSession(nextSession);
       setLoading(false);
@@ -65,11 +80,21 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
 
         if (disposed) return;
 
+        if (bootstrapFallbackId !== undefined) {
+          window.clearTimeout(bootstrapFallbackId);
+          bootstrapFallbackId = undefined;
+        }
+
         setSession(currentSession);
         setRecoveryMode(isRecoveryRedirect());
         setLoading(false);
       } catch (error) {
         if (disposed) return;
+
+        if (bootstrapFallbackId !== undefined) {
+          window.clearTimeout(bootstrapFallbackId);
+          bootstrapFallbackId = undefined;
+        }
 
         console.error("Failed to bootstrap Supabase session:", error);
         setRecoveryMode(isRecoveryRedirect());
@@ -79,6 +104,9 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
 
     onCleanup(() => {
       disposed = true;
+      if (bootstrapFallbackId !== undefined) {
+        window.clearTimeout(bootstrapFallbackId);
+      }
       subscription.unsubscribe();
     });
   });

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -37,7 +37,7 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
       return;
     }
 
-    bootstrapFallbackId = window.setTimeout(() => {
+    bootstrapFallbackId = globalThis.setTimeout(() => {
       if (disposed) return;
 
       setRecoveryMode(isRecoveryRedirect());
@@ -50,7 +50,7 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
       if (disposed) return;
 
       if (bootstrapFallbackId !== undefined) {
-        window.clearTimeout(bootstrapFallbackId);
+        globalThis.clearTimeout(bootstrapFallbackId);
         bootstrapFallbackId = undefined;
       }
 
@@ -81,7 +81,7 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
         if (disposed) return;
 
         if (bootstrapFallbackId !== undefined) {
-          window.clearTimeout(bootstrapFallbackId);
+          globalThis.clearTimeout(bootstrapFallbackId);
           bootstrapFallbackId = undefined;
         }
 
@@ -92,7 +92,7 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
         if (disposed) return;
 
         if (bootstrapFallbackId !== undefined) {
-          window.clearTimeout(bootstrapFallbackId);
+          globalThis.clearTimeout(bootstrapFallbackId);
           bootstrapFallbackId = undefined;
         }
 
@@ -105,7 +105,7 @@ export function AuthProvider(props: Readonly<{ children: JSX.Element }>) {
     onCleanup(() => {
       disposed = true;
       if (bootstrapFallbackId !== undefined) {
-        window.clearTimeout(bootstrapFallbackId);
+        globalThis.clearTimeout(bootstrapFallbackId);
       }
       subscription.unsubscribe();
     });

--- a/src/components/home/HomeShell.tsx
+++ b/src/components/home/HomeShell.tsx
@@ -7,7 +7,7 @@ interface HomeShellProps {
 export function HomeShell(props: Readonly<HomeShellProps>) {
   return (
     <main class="min-h-full">
-      <div class="mx-auto flex min-h-full w-full max-w-[1600px] flex-col gap-6 px-4 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-8">
+      <div class="mx-auto flex min-h-full w-full max-w-[min(96vw,2200px)] flex-col gap-4 px-4 py-4 sm:px-5 sm:py-5 lg:px-6 lg:py-6">
         {props.children}
       </div>
     </main>

--- a/src/components/home/LeaderboardCard.tsx
+++ b/src/components/home/LeaderboardCard.tsx
@@ -9,16 +9,20 @@ export function LeaderboardCard(props: Readonly<LeaderboardCardProps>) {
   return (
     <section class="card border-base-300 bg-base-100 text-base-content [html[data-theme=dim]_&]:bg-neutral [html[data-theme=dim]_&]:text-neutral-content h-full shadow-sm">
       <div class="card-body gap-4 p-4 sm:gap-5 sm:p-6">
-        <div class="flex items-center gap-3">
-          <div class="bg-base-200 text-base-content [html[data-theme=dim]_&]:bg-base-100/10 [html[data-theme=dim]_&]:text-neutral-content rounded-full p-2">
-            <Medal class="h-4 w-4" />
+        <div class="flex items-center justify-between gap-3">
+          <div class="flex items-center gap-3">
+            <div class="bg-base-200 text-base-content [html[data-theme=dim]_&]:bg-base-100/10 [html[data-theme=dim]_&]:text-neutral-content rounded-full p-2">
+              <Medal class="h-4 w-4" />
+            </div>
+            <div>
+              <h3 class="text-lg font-black tracking-tight sm:text-xl">Leaderboard</h3>
+              <p class="text-base-content/75 [html[data-theme=dim]_&]:text-neutral-content/75 text-sm">
+                Wins from completed matches
+              </p>
+            </div>
           </div>
-          <div>
-            <h3 class="text-lg font-black tracking-tight sm:text-xl">Leaderboard</h3>
-            <p class="text-base-content/75 [html[data-theme=dim]_&]:text-neutral-content/75 text-sm">
-              Wins from completed matches
-            </p>
-          </div>
+
+          <span class="badge badge-outline badge-sm px-3 py-3">Live</span>
         </div>
         <LeaderboardContent refreshKey={props.refreshKey} />
       </div>

--- a/src/components/home/MatchDashboard.tsx
+++ b/src/components/home/MatchDashboard.tsx
@@ -26,7 +26,7 @@ interface MatchDashboardProps {
 
 export function MatchDashboard(props: Readonly<MatchDashboardProps>) {
   return (
-    <div class="grid gap-6 xl:grid-cols-[minmax(0,2fr)_minmax(20rem,1fr)] xl:items-start">
+    <div class="grid gap-6 xl:grid-cols-[minmax(42rem,1fr)_minmax(24rem,0.45fr)] xl:items-start">
       <div class="grid gap-6">
         <ScoreBoard
           backendReady={props.backendReady}

--- a/src/components/home/MatchSetupPanel.tsx
+++ b/src/components/home/MatchSetupPanel.tsx
@@ -95,7 +95,7 @@ export function MatchSetupPanel(props: Readonly<MatchSetupPanelProps>) {
   return (
     <section class="mx-auto w-full max-w-6xl">
       <div class="card border-base-300 bg-base-100 text-base-content [html[data-theme=dim]_&]:bg-neutral [html[data-theme=dim]_&]:text-neutral-content shadow-sm">
-        <div class="card-body gap-5 p-4 sm:p-6 lg:p-8">
+        <div class="card-body gap-5 p-4 sm:p-5 lg:p-6">
           <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
             <div>
               <p class="text-base-content/60 [html[data-theme=dim]_&]:text-neutral-content/70 text-xs font-semibold tracking-[0.24em] uppercase">

--- a/src/components/leaderboard/LeaderboardContent.tsx
+++ b/src/components/leaderboard/LeaderboardContent.tsx
@@ -104,10 +104,9 @@ export function LeaderboardContent(props: Readonly<LeaderboardContentProps>) {
           summaryItems={[
             { label: activeTab() === "teams" ? "Teams" : "Players", value: rows().length },
           ]}
-          shellClass="flex min-h-[20rem] flex-col lg:min-h-[30rem]"
-          scrollAreaClass="min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
+          shellClass="flex min-h-[18rem] flex-col lg:min-h-[24rem]"
+          scrollAreaClass="min-h-0 flex-1 overflow-y-auto"
           stickyHeader
-          tableClass="min-w-0"
         />
       </Show>
     </div>

--- a/src/components/leaderboard/LeaderboardContent.tsx
+++ b/src/components/leaderboard/LeaderboardContent.tsx
@@ -1,6 +1,5 @@
 import { createMemo, createResource, createSignal, Show } from "solid-js";
 import { type ColumnDef } from "@tanstack/solid-table";
-import { Shield, Users } from "lucide-solid";
 import {
   getLeaderboardSnapshot,
   type PlayerLeaderboardRow,
@@ -40,27 +39,11 @@ export function LeaderboardContent(props: Readonly<LeaderboardContentProps>) {
       accessorKey: "name",
       header: activeTab() === "teams" ? "Team" : "Player",
       cell: (info) => {
-        const row = info.row.original;
-
         return (
           <div class="min-w-0">
-            <p class="truncate font-semibold">{row.name}</p>
-            <div class="mt-1 flex flex-wrap gap-1.5">
-              <Show when={"type" in row}>
-                <span class="badge badge-outline badge-sm gap-1">
-                  <Shield class="h-3 w-3" />
-                  Team
-                </span>
-              </Show>
-              <Show when={!("type" in row)}>
-                <span class="badge badge-outline badge-sm gap-1">
-                  <Users class="h-3 w-3" />
-                  Player
-                </span>
-              </Show>
-              <span class="badge badge-outline badge-sm sm:hidden">
-                {info.row.original.wins} wins
-              </span>
+            <p class="truncate font-semibold">{info.row.original.name}</p>
+            <div class="mt-1 flex flex-wrap gap-1.5 sm:hidden">
+              <span class="badge badge-outline badge-sm">{info.row.original.wins} wins</span>
             </div>
           </div>
         );

--- a/src/components/leaderboard/LeaderboardContent.tsx
+++ b/src/components/leaderboard/LeaderboardContent.tsx
@@ -101,6 +101,9 @@ export function LeaderboardContent(props: Readonly<LeaderboardContentProps>) {
           data={rows() as (TeamLeaderboardRow | PlayerLeaderboardRow)[]}
           emptyTitle="No completed matches yet"
           emptyDescription="Finish a game to populate the current standings."
+          shellClass="min-h-[18rem]"
+          scrollAreaClass="max-h-[22rem] overflow-auto"
+          stickyHeader
         />
       </Show>
     </div>

--- a/src/components/leaderboard/LeaderboardContent.tsx
+++ b/src/components/leaderboard/LeaderboardContent.tsx
@@ -1,9 +1,12 @@
-import { createMemo, createResource, createSignal, For, Show } from "solid-js";
+import { createMemo, createResource, createSignal, Show } from "solid-js";
+import { type ColumnDef } from "@tanstack/solid-table";
+import { Shield, Users } from "lucide-solid";
 import {
   getLeaderboardSnapshot,
   type PlayerLeaderboardRow,
   type TeamLeaderboardRow,
 } from "~/service/leaderboardService.ts";
+import { DataTable } from "~/components/shared/table/DataTable.tsx";
 
 type LeaderboardTab = "teams" | "players";
 
@@ -18,6 +21,63 @@ export function LeaderboardContent(props: Readonly<LeaderboardContentProps>) {
   const rows = createMemo(() =>
     activeTab() === "teams" ? (snapshot()?.teams ?? []) : (snapshot()?.players ?? [])
   );
+
+  const columns = createMemo<ColumnDef<TeamLeaderboardRow | PlayerLeaderboardRow>[]>(() => [
+    {
+      id: "rank",
+      header: "Rank",
+      cell: (info) => {
+        const rank = info.row.index + 1;
+
+        return (
+          <div class="bg-base-200 text-base-content flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-black">
+            {rank}
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "name",
+      header: activeTab() === "teams" ? "Team" : "Player",
+      cell: (info) => {
+        const row = info.row.original;
+
+        return (
+          <div class="min-w-0">
+            <p class="truncate font-semibold">{row.name}</p>
+            <div class="mt-1 flex flex-wrap gap-1.5">
+              <Show when={"type" in row}>
+                <span class="badge badge-outline badge-sm gap-1">
+                  <Shield class="h-3 w-3" />
+                  Team
+                </span>
+              </Show>
+              <Show when={!("type" in row)}>
+                <span class="badge badge-outline badge-sm gap-1">
+                  <Users class="h-3 w-3" />
+                  Player
+                </span>
+              </Show>
+              <span class="badge badge-outline badge-sm sm:hidden">
+                {info.row.original.wins} wins
+              </span>
+            </div>
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "wins",
+      header: "Wins",
+      meta: {
+        headerClass: "hidden text-right sm:table-cell",
+        cellClass: "hidden text-right sm:table-cell",
+      },
+      cell: (info) => (
+        <span class="text-lg font-black tracking-tight">{info.row.original.wins}</span>
+      ),
+    },
+  ]);
 
   return (
     <div class="space-y-4">
@@ -53,38 +113,12 @@ export function LeaderboardContent(props: Readonly<LeaderboardContentProps>) {
           </div>
         }
       >
-        <div class="space-y-3">
-          <div class="text-base-content/70 [html[data-theme=dim]_&]:text-neutral-content/75 hidden grid-cols-[minmax(0,1fr)_auto] gap-4 px-3 text-xs font-semibold tracking-[0.18em] uppercase sm:grid">
-            <span>Name</span>
-            <span>Wins</span>
-          </div>
-
-          <For
-            each={rows() as (TeamLeaderboardRow | PlayerLeaderboardRow)[]}
-            fallback={
-              <div class="rounded-box bg-base-200 text-base-content/75 [html[data-theme=dim]_&]:bg-base-100/10 [html[data-theme=dim]_&]:text-neutral-content/80 p-4 text-sm">
-                No completed matches yet. Finish a game to populate the rankings.
-              </div>
-            }
-          >
-            {(row, index) => (
-              <div class="rounded-box border-base-300 bg-base-200 [html[data-theme=dim]_&]:bg-base-100/10 grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 border px-3 py-3 sm:px-4">
-                <div class="bg-base-100 text-base-content flex h-9 w-9 items-center justify-center rounded-full text-sm font-black">
-                  {index() + 1}
-                </div>
-                <div class="min-w-0">
-                  <p class="truncate font-semibold">{row.name}</p>
-                  {"type" in row && (
-                    <p class="text-base-content/70 [html[data-theme=dim]_&]:text-neutral-content/75 text-xs tracking-[0.18em] uppercase">
-                      {row.type}
-                    </p>
-                  )}
-                </div>
-                <span class="text-lg font-black tracking-tight">{row.wins}</span>
-              </div>
-            )}
-          </For>
-        </div>
+        <DataTable
+          columns={columns()}
+          data={rows() as (TeamLeaderboardRow | PlayerLeaderboardRow)[]}
+          emptyTitle="No completed matches yet"
+          emptyDescription="Finish a game to populate the current standings."
+        />
       </Show>
     </div>
   );

--- a/src/components/leaderboard/LeaderboardContent.tsx
+++ b/src/components/leaderboard/LeaderboardContent.tsx
@@ -101,9 +101,13 @@ export function LeaderboardContent(props: Readonly<LeaderboardContentProps>) {
           data={rows() as (TeamLeaderboardRow | PlayerLeaderboardRow)[]}
           emptyTitle="No completed matches yet"
           emptyDescription="Finish a game to populate the current standings."
-          shellClass="min-h-[18rem]"
-          scrollAreaClass="max-h-[22rem] overflow-auto"
+          summaryItems={[
+            { label: activeTab() === "teams" ? "Teams" : "Players", value: rows().length },
+          ]}
+          shellClass="flex min-h-[20rem] flex-col lg:min-h-[30rem]"
+          scrollAreaClass="min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
           stickyHeader
+          tableClass="min-w-0"
         />
       </Show>
     </div>

--- a/src/components/leaderboard/LeaderboardPage.tsx
+++ b/src/components/leaderboard/LeaderboardPage.tsx
@@ -4,7 +4,7 @@ import { TableSection } from "~/components/shared/table/TableSection.tsx";
 export default function LeaderboardPage() {
   return (
     <div class="mx-auto flex w-full max-w-3xl flex-col gap-5 px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
-      <TableSection eyebrow="Standings" title="Leaderboard">
+      <TableSection title="Leaderboard">
         <LeaderboardContent />
       </TableSection>
     </div>

--- a/src/components/leaderboard/LeaderboardPage.tsx
+++ b/src/components/leaderboard/LeaderboardPage.tsx
@@ -3,7 +3,7 @@ import { TableSection } from "~/components/shared/table/TableSection.tsx";
 
 export default function LeaderboardPage() {
   return (
-    <div class="mx-auto flex w-full max-w-3xl flex-col gap-5 px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
+    <div class="mx-auto flex w-full max-w-3xl flex-col gap-4 px-4 py-4 sm:px-5 sm:py-5 lg:px-6">
       <TableSection title="Leaderboard">
         <LeaderboardContent />
       </TableSection>

--- a/src/components/leaderboard/LeaderboardPage.tsx
+++ b/src/components/leaderboard/LeaderboardPage.tsx
@@ -1,32 +1,19 @@
-import { Medal } from "lucide-solid";
 import { LeaderboardContent } from "~/components/leaderboard/LeaderboardContent.tsx";
+import { TableSection } from "~/components/shared/table/TableSection.tsx";
 
 export default function LeaderboardPage() {
   return (
     <div class="mx-auto flex w-full max-w-3xl flex-col gap-5 px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
-      <section class="space-y-3">
-        <div class="flex items-center gap-3">
-          <div class="bg-base-100 text-base-content [html[data-theme=dim]_&]:bg-base-100/10 [html[data-theme=dim]_&]:text-neutral-content rounded-full p-2 shadow-sm">
-            <Medal class="h-5 w-5" />
-          </div>
-          <div class="min-w-0">
-            <h1 class="text-2xl font-black tracking-tight sm:text-3xl">Leaderboard</h1>
-            <p class="text-base-content/75 [html[data-theme=dim]_&]:text-neutral-content/75 text-sm sm:text-base">
-              Wins from completed matches
-            </p>
-          </div>
-        </div>
-        <p class="text-base-content/75 [html[data-theme=dim]_&]:text-neutral-content/75 max-w-2xl text-sm leading-6 sm:text-base">
-          Rankings are based on finished matches only. Switch between team and player views to scan
-          the current standings.
-        </p>
-      </section>
-
-      <section class="card border-base-300 bg-base-100 text-base-content [html[data-theme=dim]_&]:bg-neutral [html[data-theme=dim]_&]:text-neutral-content shadow-sm">
-        <div class="card-body gap-4 p-4 sm:gap-5 sm:p-6">
-          <LeaderboardContent />
-        </div>
-      </section>
+      <TableSection
+        eyebrow="Standings"
+        title="Leaderboard"
+        description="Rankings are based on finished matches only. Switch between team and player views to scan the current standings."
+        stats={
+          <span class="badge badge-outline badge-sm px-3 py-3 whitespace-nowrap">Wins only</span>
+        }
+      >
+        <LeaderboardContent />
+      </TableSection>
     </div>
   );
 }

--- a/src/components/leaderboard/LeaderboardPage.tsx
+++ b/src/components/leaderboard/LeaderboardPage.tsx
@@ -3,7 +3,7 @@ import { TableSection } from "~/components/shared/table/TableSection.tsx";
 
 export default function LeaderboardPage() {
   return (
-    <div class="mx-auto flex w-full max-w-3xl flex-col gap-4 px-4 py-4 sm:px-5 sm:py-5 lg:px-6">
+    <div class="mx-auto flex w-full max-w-[min(96vw,1400px)] flex-col gap-4 px-4 py-4 sm:px-5 sm:py-5 lg:px-6">
       <TableSection title="Leaderboard">
         <LeaderboardContent />
       </TableSection>

--- a/src/components/leaderboard/LeaderboardPage.tsx
+++ b/src/components/leaderboard/LeaderboardPage.tsx
@@ -4,14 +4,7 @@ import { TableSection } from "~/components/shared/table/TableSection.tsx";
 export default function LeaderboardPage() {
   return (
     <div class="mx-auto flex w-full max-w-3xl flex-col gap-5 px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
-      <TableSection
-        eyebrow="Standings"
-        title="Leaderboard"
-        description="Rankings are based on finished matches only. Switch between team and player views to scan the current standings."
-        stats={
-          <span class="badge badge-outline badge-sm px-3 py-3 whitespace-nowrap">Wins only</span>
-        }
-      >
+      <TableSection eyebrow="Standings" title="Leaderboard">
         <LeaderboardContent />
       </TableSection>
     </div>

--- a/src/components/players/Players.tsx
+++ b/src/components/players/Players.tsx
@@ -1,9 +1,11 @@
 import { A } from "@solidjs/router";
 import type { RouteSectionProps } from "@solidjs/router";
 import { ColumnDef } from "@tanstack/solid-table";
+import { Users } from "lucide-solid";
 import { createResource, createSignal, Show } from "solid-js";
 import { hasSupabaseConfig, supabase } from "~/service/supabaseService.ts";
 import { DataTable } from "~/components/shared/table/DataTable.tsx";
+import { TableSection } from "~/components/shared/table/TableSection.tsx";
 import ConfirmDelete from "./ConfirmDelete";
 import { PlayerListContext } from "./PlayerListContext";
 
@@ -15,28 +17,86 @@ interface Player {
 const [showConfirm, setShowConfirm] = createSignal(false);
 const [playerToDelete, setPlayerToDelete] = createSignal<Player | null>(null);
 
+const openDeleteConfirm = (player: Player) => {
+  setPlayerToDelete(player);
+  setShowConfirm(true);
+};
+
+const getPlayerInitials = (name: string) =>
+  name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+
 const columns: ColumnDef<Player>[] = [
   {
-    header: "Actions",
+    accessorKey: "name",
+    header: "Player",
     cell: (info) => {
       const player = info.row.original;
+
+      return (
+        <div class="min-w-0 space-y-3">
+          <div class="flex min-w-0 items-center gap-3">
+            <div class="bg-primary/10 text-primary flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold">
+              {getPlayerInitials(player.name)}
+            </div>
+            <div class="min-w-0">
+              <p class="truncate font-semibold">{player.name}</p>
+              <p class="text-base-content/65 text-sm">
+                Available for teams, matches, and standings.
+              </p>
+            </div>
+          </div>
+
+          <div class="flex flex-wrap items-center gap-2 sm:hidden">
+            <span class="badge badge-outline badge-sm">Match roster</span>
+            <span class="badge badge-outline badge-sm">Team eligible</span>
+            <button
+              class="btn btn-soft btn-error btn-xs ml-auto"
+              onClick={() => openDeleteConfirm(player)}
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      );
+    },
+  },
+  {
+    header: "Usage",
+    meta: {
+      headerClass: "hidden sm:table-cell",
+      cellClass: "hidden sm:table-cell",
+    },
+    cell: () => (
+      <div class="flex flex-wrap gap-2">
+        <span class="badge badge-outline badge-sm">Match roster</span>
+        <span class="badge badge-outline badge-sm">Team eligible</span>
+      </div>
+    ),
+  },
+  {
+    id: "actions",
+    header: "Actions",
+    meta: {
+      headerClass: "hidden text-right sm:table-cell",
+      cellClass: "hidden w-0 text-right sm:table-cell",
+    },
+    cell: (info) => {
+      const player = info.row.original;
+
       return (
         <button
-          class="btn btn-soft btn-error btn-sm"
-          onClick={() => {
-            setPlayerToDelete(player);
-            setShowConfirm(true);
-          }}
+          class="btn btn-soft btn-error btn-sm min-w-24"
+          onClick={() => openDeleteConfirm(player)}
         >
           Delete
         </button>
       );
     },
-  },
-  {
-    header: "Name",
-    accessorKey: "name",
-    cell: (info) => info.getValue(),
   },
 ];
 
@@ -62,7 +122,7 @@ function Players(props: RouteSectionProps) {
       }
     >
       <PlayerListContext.Provider value={{ refetchPlayers: refetch }}>
-        <div class="h-full px-4 py-2">
+        <div class="h-full px-4 py-4 sm:px-6">
           <Show
             when={data()}
             keyed
@@ -72,13 +132,32 @@ function Players(props: RouteSectionProps) {
               </div>
             }
           >
-            {(resolvedData) => <DataTable columns={columns} data={resolvedData} />}
+            {(resolvedData) => (
+              <TableSection
+                eyebrow="Roster"
+                title="Players"
+                description="Manage the people available for match setup. The table structure leaves room for future stats without changing the surrounding page."
+                stats={
+                  <span class="badge badge-outline badge-sm gap-2 px-3 py-3">
+                    <Users class="h-3.5 w-3.5" />
+                    {resolvedData.length} {resolvedData.length === 1 ? "player" : "players"}
+                  </span>
+                }
+                actions={
+                  <A class="btn btn-primary btn-sm sm:btn-md min-w-40" href="/players/new">
+                    Create New Player
+                  </A>
+                }
+              >
+                <DataTable
+                  columns={columns}
+                  data={resolvedData}
+                  emptyTitle="No players yet"
+                  emptyDescription="Create a player to start building teams and tracking matches."
+                />
+              </TableSection>
+            )}
           </Show>
-          <div class="mt-4 text-center">
-            <A class="btn btn-primary btn-sm sm:btn-md min-w-40" href="/players/new">
-              Create New Player
-            </A>
-          </div>
         </div>
 
         {props.children}

--- a/src/components/players/Players.tsx
+++ b/src/components/players/Players.tsx
@@ -100,7 +100,7 @@ function Players(props: RouteSectionProps) {
       }
     >
       <PlayerListContext.Provider value={{ refetchPlayers: refetch }}>
-        <div class="mx-auto h-full w-full max-w-3xl px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
+        <div class="mx-auto h-full w-full max-w-[min(96vw,1400px)] px-4 py-4 sm:px-5 sm:py-5 lg:px-6">
           <Show
             when={data()}
             keyed

--- a/src/components/players/Players.tsx
+++ b/src/components/players/Players.tsx
@@ -38,24 +38,16 @@ const columns: ColumnDef<Player>[] = [
       const player = info.row.original;
 
       return (
-        <div class="min-w-0 space-y-3">
-          <div class="flex min-w-0 items-center gap-3">
-            <div class="bg-primary/10 text-primary flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold">
-              {getPlayerInitials(player.name)}
-            </div>
-            <div class="min-w-0">
-              <p class="truncate font-semibold">{player.name}</p>
-              <p class="text-base-content/65 text-sm">
-                Available for teams, matches, and standings.
-              </p>
-            </div>
+        <div class="flex min-w-0 items-center gap-3">
+          <div class="bg-primary/10 text-primary flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold">
+            {getPlayerInitials(player.name)}
           </div>
-
-          <div class="flex flex-wrap items-center gap-2 sm:hidden">
-            <span class="badge badge-outline badge-sm">Match roster</span>
-            <span class="badge badge-outline badge-sm">Team eligible</span>
+          <div class="min-w-0 flex-1">
+            <p class="truncate font-semibold">{player.name}</p>
+          </div>
+          <div class="sm:hidden">
             <button
-              class="btn btn-soft btn-error btn-xs ml-auto"
+              class="btn btn-soft btn-error btn-xs min-w-18"
               onClick={() => openDeleteConfirm(player)}
             >
               Delete
@@ -64,19 +56,6 @@ const columns: ColumnDef<Player>[] = [
         </div>
       );
     },
-  },
-  {
-    header: "Usage",
-    meta: {
-      headerClass: "hidden sm:table-cell",
-      cellClass: "hidden sm:table-cell",
-    },
-    cell: () => (
-      <div class="flex flex-wrap gap-2">
-        <span class="badge badge-outline badge-sm">Match roster</span>
-        <span class="badge badge-outline badge-sm">Team eligible</span>
-      </div>
-    ),
   },
   {
     id: "actions",
@@ -136,7 +115,6 @@ function Players(props: RouteSectionProps) {
               <TableSection
                 eyebrow="Roster"
                 title="Players"
-                description="Manage the people available for match setup. The table structure leaves room for future stats without changing the surrounding page."
                 stats={
                   <span class="badge badge-outline badge-sm gap-2 px-3 py-3">
                     <Users class="h-3.5 w-3.5" />

--- a/src/components/players/Players.tsx
+++ b/src/components/players/Players.tsx
@@ -1,7 +1,6 @@
 import { A } from "@solidjs/router";
 import type { RouteSectionProps } from "@solidjs/router";
 import { ColumnDef } from "@tanstack/solid-table";
-import { Users } from "lucide-solid";
 import { createResource, createSignal, Show } from "solid-js";
 import { hasSupabaseConfig, supabase } from "~/service/supabaseService.ts";
 import { DataTable } from "~/components/shared/table/DataTable.tsx";
@@ -101,7 +100,7 @@ function Players(props: RouteSectionProps) {
       }
     >
       <PlayerListContext.Provider value={{ refetchPlayers: refetch }}>
-        <div class="h-full px-4 py-4 sm:px-6">
+        <div class="mx-auto h-full w-full max-w-3xl px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
           <Show
             when={data()}
             keyed
@@ -113,17 +112,13 @@ function Players(props: RouteSectionProps) {
           >
             {(resolvedData) => (
               <TableSection
-                eyebrow="Roster"
                 title="Players"
-                stats={
-                  <span class="badge badge-outline badge-sm gap-2 px-3 py-3">
-                    <Users class="h-3.5 w-3.5" />
-                    {resolvedData.length} {resolvedData.length === 1 ? "player" : "players"}
-                  </span>
-                }
                 actions={
-                  <A class="btn btn-primary btn-sm sm:btn-md min-w-40" href="/players/new">
-                    Create New Player
+                  <A
+                    class="btn btn-primary btn-sm sm:btn-md w-full sm:min-w-40"
+                    href="/players/new"
+                  >
+                    Create player
                   </A>
                 }
               >
@@ -132,6 +127,7 @@ function Players(props: RouteSectionProps) {
                   data={resolvedData}
                   emptyTitle="No players yet"
                   emptyDescription="Create a player to start building teams and tracking matches."
+                  summaryItems={[{ label: "Players", value: resolvedData.length }]}
                 />
               </TableSection>
             )}

--- a/src/components/shared/table/DataTable.tsx
+++ b/src/components/shared/table/DataTable.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from "solid-js";
 import { For, Show } from "solid-js";
 import { ColumnDef, createSolidTable, flexRender, getCoreRowModel } from "@tanstack/solid-table";
 import {
@@ -11,6 +12,15 @@ import {
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  emptyTitle?: string;
+  emptyDescription?: string;
+  emptyAction?: JSX.Element;
+  tableClass?: string;
+}
+
+interface ColumnMeta {
+  headerClass?: string;
+  cellClass?: string;
 }
 
 export function DataTable<TData, TValue>(props: Readonly<DataTableProps<TData, TValue>>) {
@@ -25,52 +35,64 @@ export function DataTable<TData, TValue>(props: Readonly<DataTableProps<TData, T
   });
 
   return (
-    <>
-      <Table class={"w-full"}>
-        <TableHeader>
-          <For each={table.getHeaderGroups()}>
-            {(headerGroup) => (
-              <TableRow>
-                <For each={headerGroup.headers}>
-                  {(header) => (
-                    <TableCell isHeader colSpan={header.colSpan}>
+    <Table class={props.tableClass}>
+      <TableHeader>
+        <For each={table.getHeaderGroups()}>
+          {(headerGroup) => (
+            <TableRow>
+              <For each={headerGroup.headers}>
+                {(header) => {
+                  const meta = (header.column.columnDef.meta ?? {}) as ColumnMeta;
+
+                  return (
+                    <TableCell isHeader class={meta.headerClass} colSpan={header.colSpan}>
                       <Show when={!header.isPlaceholder}>
                         {flexRender(header.column.columnDef.header, header.getContext())}
                       </Show>
                     </TableCell>
-                  )}
+                  );
+                }}
+              </For>
+            </TableRow>
+          )}
+        </For>
+      </TableHeader>
+      <TableBody>
+        <Show
+          when={table.getRowModel().rows?.length}
+          fallback={
+            <TableRow>
+              <TableCell colSpan={props.columns.length} class="px-6 py-10">
+                <div class="flex flex-col items-center gap-2 text-center">
+                  <p class="text-sm font-semibold">{props.emptyTitle ?? "No rows yet"}</p>
+                  <p class="text-base-content/70 max-w-md text-sm">
+                    {props.emptyDescription ?? "Add your first item to populate this table."}
+                  </p>
+                  <Show when={props.emptyAction}>{props.emptyAction}</Show>
+                </div>
+              </TableCell>
+            </TableRow>
+          }
+        >
+          <For each={table.getRowModel().rows}>
+            {(row) => (
+              <TableRow data-state={row.getIsSelected() && "selected"}>
+                <For each={row.getVisibleCells()}>
+                  {(cell) => {
+                    const meta = (cell.column.columnDef.meta ?? {}) as ColumnMeta;
+
+                    return (
+                      <TableCell class={meta.cellClass}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    );
+                  }}
                 </For>
               </TableRow>
             )}
           </For>
-        </TableHeader>
-        <TableBody>
-          <Show
-            when={table.getRowModel().rows?.length}
-            fallback={
-              <TableRow>
-                <TableCell colSpan={props.columns.length} class="h-24 text-center">
-                  No results.
-                </TableCell>
-              </TableRow>
-            }
-          >
-            <For each={table.getRowModel().rows}>
-              {(row) => (
-                <TableRow data-state={row.getIsSelected() && "selected"}>
-                  <For each={row.getVisibleCells()}>
-                    {(cell) => (
-                      <TableCell>
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </TableCell>
-                    )}
-                  </For>
-                </TableRow>
-              )}
-            </For>
-          </Show>
-        </TableBody>
-      </Table>
-    </>
+        </Show>
+      </TableBody>
+    </Table>
   );
 }

--- a/src/components/shared/table/DataTable.tsx
+++ b/src/components/shared/table/DataTable.tsx
@@ -8,6 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from "~/components/shared/table/Table.tsx";
+import { cn } from "~/lib/utils";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -15,12 +16,22 @@ interface DataTableProps<TData, TValue> {
   emptyTitle?: string;
   emptyDescription?: string;
   emptyAction?: JSX.Element;
+  summaryItems?: DataTableSummaryItem[];
+  showSummary?: boolean;
+  shellClass?: string;
+  scrollAreaClass?: string;
+  stickyHeader?: boolean;
   tableClass?: string;
 }
 
 interface ColumnMeta {
   headerClass?: string;
   cellClass?: string;
+}
+
+interface DataTableSummaryItem {
+  label: string;
+  value: JSX.Element | string | number;
 }
 
 export function DataTable<TData, TValue>(props: Readonly<DataTableProps<TData, TValue>>) {
@@ -34,65 +45,97 @@ export function DataTable<TData, TValue>(props: Readonly<DataTableProps<TData, T
     getCoreRowModel: getCoreRowModel(),
   });
 
+  const summaryItems = () => props.summaryItems ?? [];
+  const showSummary = () => props.showSummary ?? summaryItems().length > 0;
+
   return (
-    <Table class={props.tableClass}>
-      <TableHeader>
-        <For each={table.getHeaderGroups()}>
-          {(headerGroup) => (
-            <TableRow>
-              <For each={headerGroup.headers}>
-                {(header) => {
-                  const meta = (header.column.columnDef.meta ?? {}) as ColumnMeta;
-
-                  return (
-                    <TableCell isHeader class={meta.headerClass} colSpan={header.colSpan}>
-                      <Show when={!header.isPlaceholder}>
-                        {flexRender(header.column.columnDef.header, header.getContext())}
-                      </Show>
-                    </TableCell>
-                  );
-                }}
-              </For>
-            </TableRow>
-          )}
-        </For>
-      </TableHeader>
-      <TableBody>
-        <Show
-          when={table.getRowModel().rows?.length}
-          fallback={
-            <TableRow>
-              <TableCell colSpan={props.columns.length} class="px-6 py-10">
-                <div class="flex flex-col items-center gap-2 text-center">
-                  <p class="text-sm font-semibold">{props.emptyTitle ?? "No rows yet"}</p>
-                  <p class="text-base-content/70 max-w-md text-sm">
-                    {props.emptyDescription ?? "Add your first item to populate this table."}
-                  </p>
-                  <Show when={props.emptyAction}>{props.emptyAction}</Show>
-                </div>
-              </TableCell>
-            </TableRow>
-          }
-        >
-          <For each={table.getRowModel().rows}>
-            {(row) => (
-              <TableRow data-state={row.getIsSelected() && "selected"}>
-                <For each={row.getVisibleCells()}>
-                  {(cell) => {
-                    const meta = (cell.column.columnDef.meta ?? {}) as ColumnMeta;
-
-                    return (
-                      <TableCell class={meta.cellClass}>
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </TableCell>
-                    );
-                  }}
-                </For>
-              </TableRow>
+    <div
+      class={cn("rounded-box border-base-300 bg-base-100 overflow-hidden border", props.shellClass)}
+    >
+      <div class={cn("w-full overflow-x-auto", props.scrollAreaClass)}>
+        <Table class={props.tableClass}>
+          <TableHeader
+            class={cn(
+              props.stickyHeader &&
+                "[&_th]:bg-base-200/95 supports-[backdrop-filter]:[&_th]:bg-base-200/80 [&_th]:sticky [&_th]:top-0 [&_th]:z-10 [&_th]:backdrop-blur"
             )}
-          </For>
-        </Show>
-      </TableBody>
-    </Table>
+          >
+            <For each={table.getHeaderGroups()}>
+              {(headerGroup) => (
+                <TableRow>
+                  <For each={headerGroup.headers}>
+                    {(header) => {
+                      const meta = (header.column.columnDef.meta ?? {}) as ColumnMeta;
+
+                      return (
+                        <TableCell isHeader class={meta.headerClass} colSpan={header.colSpan}>
+                          <Show when={!header.isPlaceholder}>
+                            {flexRender(header.column.columnDef.header, header.getContext())}
+                          </Show>
+                        </TableCell>
+                      );
+                    }}
+                  </For>
+                </TableRow>
+              )}
+            </For>
+          </TableHeader>
+          <TableBody>
+            <Show
+              when={table.getRowModel().rows?.length}
+              fallback={
+                <TableRow>
+                  <TableCell colSpan={props.columns.length} class="px-6 py-10">
+                    <div class="flex flex-col items-center gap-2 text-center">
+                      <p class="text-sm font-semibold">{props.emptyTitle ?? "No rows yet"}</p>
+                      <p class="text-base-content/70 max-w-md text-sm">
+                        {props.emptyDescription ?? "Add your first item to populate this table."}
+                      </p>
+                      <Show when={props.emptyAction}>{props.emptyAction}</Show>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              }
+            >
+              <For each={table.getRowModel().rows}>
+                {(row) => (
+                  <TableRow data-state={row.getIsSelected() && "selected"}>
+                    <For each={row.getVisibleCells()}>
+                      {(cell) => {
+                        const meta = (cell.column.columnDef.meta ?? {}) as ColumnMeta;
+
+                        return (
+                          <TableCell class={meta.cellClass}>
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          </TableCell>
+                        );
+                      }}
+                    </For>
+                  </TableRow>
+                )}
+              </For>
+            </Show>
+          </TableBody>
+        </Table>
+      </div>
+
+      <Show when={showSummary()}>
+        <div class="border-base-300 bg-base-200/40 flex flex-col gap-2 border-t px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-5">
+          <span class="text-base-content/60 text-[0.7rem] font-semibold tracking-[0.16em] uppercase">
+            Totals
+          </span>
+          <div class="flex flex-wrap items-center gap-x-5 gap-y-1">
+            <For each={summaryItems()}>
+              {(item) => (
+                <div class="flex items-baseline gap-2 text-sm">
+                  <span class="text-base-content/65">{item.label}</span>
+                  <span class="font-semibold tabular-nums">{item.value}</span>
+                </div>
+              )}
+            </For>
+          </div>
+        </div>
+      </Show>
+    </div>
   );
 }

--- a/src/components/shared/table/Table.tsx
+++ b/src/components/shared/table/Table.tsx
@@ -54,7 +54,7 @@ export const TableRow: ParentComponent<JSX.HTMLAttributes<HTMLTableRowElement>> 
 
 interface TableCellProps extends Omit<JSX.TdHTMLAttributes<HTMLTableCellElement>, "height"> {
   isHeader?: boolean;
-  height?: string | undefined;
+  height?: string;
 }
 
 export const TableCell: ParentComponent<TableCellProps> = (rawProps) => {

--- a/src/components/shared/table/Table.tsx
+++ b/src/components/shared/table/Table.tsx
@@ -4,7 +4,7 @@ import { cn } from "~/lib/utils";
 export const Table: ParentComponent<ComponentProps<"table">> = (rawProps) => {
   const [local, others] = splitProps(rawProps, ["class", "children"]);
   return (
-    <table class={cn("table w-full min-w-full sm:min-w-[40rem]", local.class)} {...others}>
+    <table class={cn("table w-full min-w-0 table-fixed", local.class)} {...others}>
       {local.children}
     </table>
   );

--- a/src/components/shared/table/Table.tsx
+++ b/src/components/shared/table/Table.tsx
@@ -1,68 +1,50 @@
 import { ComponentProps, JSX, ParentComponent, Show, splitProps } from "solid-js";
 import { cn } from "~/lib/utils";
 
-/**
- * Table Wrapper
- * Renders a <table> wrapped in a scrollable container with DaisyUI classes.
- */
 export const Table: ParentComponent<ComponentProps<"table">> = (rawProps) => {
   const [local, others] = splitProps(rawProps, ["class", "children"]);
   return (
-    <div class="rounded-box border-base-300 bg-base-100 overflow-x-auto border shadow-sm">
-      {/* DaisyUI "table" plus "table-compact" for a clean modern look. */}
-      <table class={cn("table-compact table w-full", local.class)} {...others}>
+    <div class="rounded-box border-base-300 bg-base-100 w-full overflow-x-auto border">
+      <table class={cn("table w-full min-w-full sm:min-w-[40rem]", local.class)} {...others}>
         {local.children}
       </table>
     </div>
   );
 };
 
-/**
- * TableHeader
- * Renders a <thead> with optional class overrides.
- */
 export const TableHeader: ParentComponent<JSX.HTMLAttributes<HTMLTableSectionElement>> = (
   rawProps
 ) => {
   const [local, others] = splitProps(rawProps, ["class", "children"]);
   return (
-    /* Give the header a subtle background.
-       "bg-base-200" is typically lighter, you can tweak to taste. */
-    <thead class={cn("bg-base-200/80", local.class)} {...others}>
+    <thead
+      class={cn(
+        "bg-base-200/70 text-base-content/70 [&_th]:border-base-300 [&_th]:border-b",
+        local.class
+      )}
+      {...others}
+    >
       {local.children}
     </thead>
   );
 };
 
-/**
- * TableBody
- * Renders a <tbody> with optional class overrides.
- */
 export const TableBody: ParentComponent<JSX.HTMLAttributes<HTMLTableSectionElement>> = (
   rawProps
 ) => {
   const [local, others] = splitProps(rawProps, ["class", "children"]);
   return (
-    <tbody class={cn("", local.class)} {...others}>
+    <tbody class={cn("[&_tr:last-child]:border-b-0", local.class)} {...others}>
       {local.children}
     </tbody>
   );
 };
 
-/**
- * TableRow
- * Renders a <tr> with optional class overrides.
- * Default includes "hover" for a hover highlight.
- */
 export const TableRow: ParentComponent<JSX.HTMLAttributes<HTMLTableRowElement>> = (rawProps) => {
   const [local, others] = splitProps(rawProps, ["class", "children"]);
   return (
     <tr
-      class={cn(
-        // "hover" from DaisyUI highlights row on hover
-        "hover:bg-base-200 transition-colors",
-        local.class
-      )}
+      class={cn("border-base-300 hover:bg-base-200/60 border-b transition-colors", local.class)}
       {...others}
     >
       {local.children}
@@ -70,13 +52,9 @@ export const TableRow: ParentComponent<JSX.HTMLAttributes<HTMLTableRowElement>> 
   );
 };
 
-/**
- * TableCell
- * Renders either a <th> or <td> depending on `isHeader` prop.
- */
 interface TableCellProps extends Omit<JSX.TdHTMLAttributes<HTMLTableCellElement>, "height"> {
   isHeader?: boolean;
-  height?: string | undefined; // Explicitly type height as string or undefined
+  height?: string | undefined;
 }
 
 export const TableCell: ParentComponent<TableCellProps> = (rawProps) => {
@@ -86,13 +64,18 @@ export const TableCell: ParentComponent<TableCellProps> = (rawProps) => {
     <Show
       when={local.isHeader}
       fallback={
-        <td class={cn("px-4 py-2", local.class)} {...others}>
+        <td class={cn("px-4 py-4 align-top text-sm sm:px-5", local.class)} {...others}>
           {local.children}
         </td>
       }
     >
-      {/* Typically table headers might be bolder or uppercased */}
-      <th class={cn("px-4 py-2 font-semibold", local.class)} {...others}>
+      <th
+        class={cn(
+          "px-4 py-3 text-left text-[0.7rem] font-semibold tracking-[0.16em] uppercase sm:px-5",
+          local.class
+        )}
+        {...others}
+      >
         {local.children}
       </th>
     </Show>

--- a/src/components/shared/table/Table.tsx
+++ b/src/components/shared/table/Table.tsx
@@ -4,11 +4,9 @@ import { cn } from "~/lib/utils";
 export const Table: ParentComponent<ComponentProps<"table">> = (rawProps) => {
   const [local, others] = splitProps(rawProps, ["class", "children"]);
   return (
-    <div class="rounded-box border-base-300 bg-base-100 w-full overflow-x-auto border">
-      <table class={cn("table w-full min-w-full sm:min-w-[40rem]", local.class)} {...others}>
-        {local.children}
-      </table>
-    </div>
+    <table class={cn("table w-full min-w-full sm:min-w-[40rem]", local.class)} {...others}>
+      {local.children}
+    </table>
   );
 };
 

--- a/src/components/shared/table/TableSection.tsx
+++ b/src/components/shared/table/TableSection.tsx
@@ -1,0 +1,55 @@
+import type { JSX, ParentComponent } from "solid-js";
+import { Show, splitProps } from "solid-js";
+import { cn } from "~/lib/utils";
+
+interface TableSectionProps extends JSX.HTMLAttributes<HTMLElement> {
+  eyebrow?: string;
+  title: string;
+  description: string;
+  stats?: JSX.Element;
+  actions?: JSX.Element;
+}
+
+export const TableSection: ParentComponent<TableSectionProps> = (rawProps) => {
+  const [local, others] = splitProps(rawProps, [
+    "class",
+    "children",
+    "eyebrow",
+    "title",
+    "description",
+    "stats",
+    "actions",
+  ]);
+
+  return (
+    <section
+      class={cn("card card-border border-base-300 bg-base-100 shadow-sm", local.class)}
+      {...others}
+    >
+      <div class="card-body gap-5 p-4 sm:p-6">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div class="space-y-2">
+            <Show when={local.eyebrow}>
+              <p class="text-base-content/60 text-xs font-semibold tracking-[0.24em] uppercase">
+                {local.eyebrow}
+              </p>
+            </Show>
+            <div class="space-y-1">
+              <h1 class="card-title text-2xl">{local.title}</h1>
+              <p class="text-base-content/70 max-w-2xl text-sm">{local.description}</p>
+            </div>
+          </div>
+
+          <div class="flex flex-col items-stretch gap-3 sm:items-end">
+            <Show when={local.stats}>
+              <div class="flex flex-wrap justify-start gap-2 sm:justify-end">{local.stats}</div>
+            </Show>
+            <Show when={local.actions}>{local.actions}</Show>
+          </div>
+        </div>
+
+        {local.children}
+      </div>
+    </section>
+  );
+};

--- a/src/components/shared/table/TableSection.tsx
+++ b/src/components/shared/table/TableSection.tsx
@@ -5,7 +5,7 @@ import { cn } from "~/lib/utils";
 interface TableSectionProps extends JSX.HTMLAttributes<HTMLElement> {
   eyebrow?: string;
   title: string;
-  description: string;
+  description?: string;
   stats?: JSX.Element;
   actions?: JSX.Element;
 }
@@ -36,7 +36,9 @@ export const TableSection: ParentComponent<TableSectionProps> = (rawProps) => {
             </Show>
             <div class="space-y-1">
               <h1 class="card-title text-2xl">{local.title}</h1>
-              <p class="text-base-content/70 max-w-2xl text-sm">{local.description}</p>
+              <Show when={local.description}>
+                <p class="text-base-content/70 max-w-2xl text-sm">{local.description}</p>
+              </Show>
             </div>
           </div>
 

--- a/src/components/shared/table/TableSection.tsx
+++ b/src/components/shared/table/TableSection.tsx
@@ -26,8 +26,8 @@ export const TableSection: ParentComponent<TableSectionProps> = (rawProps) => {
       class={cn("card card-border border-base-300 bg-base-100 shadow-sm", local.class)}
       {...others}
     >
-      <div class="card-body gap-5 p-4 sm:p-6">
-        <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div class="card-body gap-5 p-4 sm:gap-6 sm:p-6">
+        <div class="flex flex-col gap-4">
           <div class="space-y-2">
             <Show when={local.eyebrow}>
               <p class="text-base-content/60 text-xs font-semibold tracking-[0.24em] uppercase">
@@ -42,12 +42,22 @@ export const TableSection: ParentComponent<TableSectionProps> = (rawProps) => {
             </div>
           </div>
 
-          <div class="flex flex-col items-stretch gap-3 sm:items-end">
-            <Show when={local.stats}>
-              <div class="flex flex-wrap justify-start gap-2 sm:justify-end">{local.stats}</div>
-            </Show>
-            <Show when={local.actions}>{local.actions}</Show>
-          </div>
+          <Show when={local.stats || local.actions}>
+            <div class="rounded-box border-base-300 bg-base-200/40 border p-2 sm:p-3">
+              <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <Show when={local.stats}>
+                  <div class="flex flex-wrap items-center gap-x-4 gap-y-2 px-2 sm:px-1">
+                    {local.stats}
+                  </div>
+                </Show>
+                <Show when={local.actions}>
+                  <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+                    {local.actions}
+                  </div>
+                </Show>
+              </div>
+            </div>
+          </Show>
         </div>
 
         {local.children}

--- a/src/components/sounds/SoundsPage.tsx
+++ b/src/components/sounds/SoundsPage.tsx
@@ -1,13 +1,4 @@
-import {
-  createMemo,
-  createResource,
-  createSignal,
-  For,
-  Match,
-  onCleanup,
-  Show,
-  Switch,
-} from "solid-js";
+import { createMemo, createResource, createSignal, Match, onCleanup, Show, Switch } from "solid-js";
 import { AudioLines, Upload, Volume2, VolumeX } from "lucide-solid";
 import { HomeShell } from "~/components/home/HomeShell.tsx";
 import Spinner from "~/components/shared/Spinner.tsx";
@@ -15,10 +6,14 @@ import { getCurrentProfile } from "~/service/profileService.ts";
 import {
   createSoundAsset,
   listSoundAssets,
+  type SoundAsset,
   type ManagedSoundType,
   updateSoundAssetStatus,
   validateSoundUpload,
 } from "~/service/soundService.ts";
+import { DataTable } from "~/components/shared/table/DataTable.tsx";
+import { TableSection } from "~/components/shared/table/TableSection.tsx";
+import { type ColumnDef } from "@tanstack/solid-table";
 
 const EMPTY_CAPTIONS_TRACK =
   "data:text/vtt;charset=utf-8,WEBVTT%0A%0A00:00:00.000%20--%3E%2000:00:00.001%0A%20";
@@ -31,6 +26,15 @@ function formatBytes(sizeBytes: number) {
 
 function formatDuration(durationMs: number) {
   return `${(durationMs / 1000).toFixed(2)}s`;
+}
+
+function getSoundInitials(name: string) {
+  return name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
 }
 
 export default function SoundsPage() {
@@ -182,6 +186,162 @@ export default function SoundsPage() {
       setUpdatingIds((ids) => ids.filter((value) => value !== id));
     }
   };
+
+  const columns: ColumnDef<SoundAsset>[] = [
+    {
+      accessorKey: "name",
+      header: "Sound",
+      cell: (info) => {
+        const asset = info.row.original;
+
+        return (
+          <div class="min-w-0 space-y-3">
+            <div class="flex min-w-0 items-center gap-3">
+              <div class="bg-primary/10 text-primary flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold">
+                {getSoundInitials(asset.name)}
+              </div>
+              <div class="min-w-0">
+                <p class="truncate font-semibold">{asset.name}</p>
+                <div class="mt-1 flex flex-wrap gap-1.5">
+                  <span
+                    class={`badge badge-outline badge-sm capitalize ${
+                      asset.type === "goal" ? "badge-primary" : "badge-secondary"
+                    }`}
+                  >
+                    {asset.type}
+                  </span>
+                  <span
+                    class={`badge badge-sm capitalize ${
+                      asset.status === "ready" ? "badge-success" : "badge-warning"
+                    }`}
+                  >
+                    {asset.status}
+                  </span>
+                  <Show when={asset.isDefault}>
+                    <span class="badge badge-outline badge-sm">Default</span>
+                  </Show>
+                </div>
+              </div>
+            </div>
+
+            <div class="grid gap-2 text-sm sm:hidden">
+              <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+                <span class="text-base-content/70">
+                  Duration {formatDuration(asset.durationMs)}
+                </span>
+                <span class="text-base-content/70">Size {formatBytes(asset.sizeBytes)}</span>
+              </div>
+              <audio class="w-full" controls preload="metadata" src={asset.url}>
+                <track
+                  default
+                  kind="captions"
+                  label="No captions available"
+                  src={EMPTY_CAPTIONS_TRACK}
+                  srclang="en"
+                />
+              </audio>
+              <button
+                class={`btn btn-xs min-w-28 ${
+                  asset.status === "ready" ? "btn-soft btn-error" : "btn-outline"
+                }`}
+                disabled={updatingIds().includes(asset.id)}
+                onClick={() => void toggleStatus(asset.id, asset.status)}
+                type="button"
+              >
+                {updatingIds().includes(asset.id)
+                  ? "Saving..."
+                  : asset.status === "ready"
+                    ? "Disable"
+                    : "Enable"}
+              </button>
+            </div>
+          </div>
+        );
+      },
+    },
+    {
+      header: "Details",
+      meta: {
+        headerClass: "hidden lg:table-cell",
+        cellClass: "hidden lg:table-cell",
+      },
+      cell: (info) => {
+        const asset = info.row.original;
+
+        return (
+          <div class="text-base-content/70 grid gap-2 text-sm">
+            <div>
+              <div class="text-base-content/60 text-[0.68rem] font-semibold tracking-[0.16em] uppercase">
+                Duration
+              </div>
+              <div>{formatDuration(asset.durationMs)}</div>
+            </div>
+            <div>
+              <div class="text-base-content/60 text-[0.68rem] font-semibold tracking-[0.16em] uppercase">
+                Size
+              </div>
+              <div>{formatBytes(asset.sizeBytes)}</div>
+            </div>
+            <div>
+              <div class="text-base-content/60 text-[0.68rem] font-semibold tracking-[0.16em] uppercase">
+                Source
+              </div>
+              <div class="max-w-52 truncate">{asset.storagePath}</div>
+            </div>
+          </div>
+        );
+      },
+    },
+    {
+      id: "preview",
+      header: "Preview",
+      meta: {
+        headerClass: "hidden md:table-cell",
+        cellClass: "hidden md:table-cell md:min-w-64",
+      },
+      cell: (info) => {
+        const asset = info.row.original;
+
+        return (
+          <audio class="w-full min-w-52" controls preload="metadata" src={asset.url}>
+            <track
+              default
+              kind="captions"
+              label="No captions available"
+              src={EMPTY_CAPTIONS_TRACK}
+              srclang="en"
+            />
+          </audio>
+        );
+      },
+    },
+    {
+      id: "actions",
+      header: "Actions",
+      meta: {
+        headerClass: "hidden text-right md:table-cell",
+        cellClass: "hidden w-0 text-right md:table-cell",
+      },
+      cell: (info) => {
+        const asset = info.row.original;
+        const isUpdating = () => updatingIds().includes(asset.id);
+
+        return (
+          <button
+            class={`btn btn-sm min-w-28 gap-2 ${
+              asset.status === "ready" ? "btn-soft btn-error" : "btn-outline"
+            }`}
+            disabled={isUpdating()}
+            onClick={() => void toggleStatus(asset.id, asset.status)}
+            type="button"
+          >
+            {asset.status === "ready" ? <VolumeX class="h-4 w-4" /> : <Volume2 class="h-4 w-4" />}
+            {isUpdating() ? "Saving..." : asset.status === "ready" ? "Disable" : "Enable"}
+          </button>
+        );
+      },
+    },
+  ];
 
   return (
     <HomeShell>
@@ -368,118 +528,53 @@ export default function SoundsPage() {
               </div>
             </div>
 
-            <div class="card card-border border-base-300 bg-base-100 shadow-sm">
-              <div class="card-body gap-4">
-                <div class="flex items-center justify-between gap-3">
-                  <div>
-                    <h2 class="card-title text-2xl">Existing sounds</h2>
-                    <p class="text-base-content/70 text-sm">
-                      Ready sounds are eligible for playback. Disabled sounds stay in the library
-                      but are skipped.
-                    </p>
-                  </div>
-                  <button class="btn btn-ghost btn-sm" onClick={refetch} type="button">
-                    Refresh
-                  </button>
-                </div>
-
-                <Show
-                  when={soundAssets()}
-                  fallback={
+            <Show
+              when={soundAssets()}
+              fallback={
+                <div class="card card-border border-base-300 bg-base-100 shadow-sm">
+                  <div class="card-body">
                     <div class="flex min-h-32 items-center justify-center">
                       <Spinner />
                     </div>
+                  </div>
+                </div>
+              }
+            >
+              {(assets) => (
+                <TableSection
+                  eyebrow="Library"
+                  title="Existing sounds"
+                  description="Ready sounds are eligible for playback. Disabled sounds stay in the library but are skipped."
+                  stats={
+                    <>
+                      <span class="badge badge-outline badge-sm gap-2 px-3 py-3">
+                        <AudioLines class="h-3.5 w-3.5" />
+                        {assets().length} assets
+                      </span>
+                      <span class="badge badge-outline badge-sm px-3 py-3">
+                        {assets().filter((asset) => asset.status === "ready").length} ready
+                      </span>
+                    </>
+                  }
+                  actions={
+                    <button
+                      class="btn btn-outline btn-sm sm:btn-md min-w-28"
+                      onClick={refetch}
+                      type="button"
+                    >
+                      Refresh
+                    </button>
                   }
                 >
-                  {(assets) => (
-                    <div class="grid gap-4">
-                      <For each={assets()}>
-                        {(asset) => {
-                          const isUpdating = () => updatingIds().includes(asset.id);
-                          const toggleStatusLabel = () => {
-                            if (isUpdating()) {
-                              return "Saving...";
-                            }
-
-                            return asset.status === "ready" ? "Disable" : "Enable";
-                          };
-
-                          return (
-                            <div class="border-base-300 rounded-box grid gap-4 border p-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
-                              <div class="grid gap-4">
-                                <div class="flex flex-wrap items-center gap-2">
-                                  <h3 class="text-lg font-semibold">{asset.name}</h3>
-                                  <span
-                                    class={`badge ${asset.type === "goal" ? "badge-primary" : "badge-secondary"} badge-outline capitalize`}
-                                  >
-                                    {asset.type}
-                                  </span>
-                                  <span
-                                    class={`badge ${asset.status === "ready" ? "badge-success" : "badge-warning"} capitalize`}
-                                  >
-                                    {asset.status}
-                                  </span>
-                                  <Show when={asset.isDefault}>
-                                    <span class="badge badge-outline">Default</span>
-                                  </Show>
-                                </div>
-
-                                <div class="text-base-content/70 grid gap-2 text-sm sm:grid-cols-3">
-                                  <div>
-                                    <div class="text-base-content/60 text-xs font-semibold uppercase">
-                                      Duration
-                                    </div>
-                                    <div>{formatDuration(asset.durationMs)}</div>
-                                  </div>
-                                  <div>
-                                    <div class="text-base-content/60 text-xs font-semibold uppercase">
-                                      Size
-                                    </div>
-                                    <div>{formatBytes(asset.sizeBytes)}</div>
-                                  </div>
-                                  <div>
-                                    <div class="text-base-content/60 text-xs font-semibold uppercase">
-                                      Source
-                                    </div>
-                                    <div class="truncate">{asset.storagePath}</div>
-                                  </div>
-                                </div>
-
-                                <audio class="w-full" controls preload="metadata" src={asset.url}>
-                                  <track
-                                    default
-                                    kind="captions"
-                                    label="No captions available"
-                                    src={EMPTY_CAPTIONS_TRACK}
-                                    srclang="en"
-                                  />
-                                </audio>
-                              </div>
-
-                              <div class="flex justify-end">
-                                <button
-                                  class={`btn ${asset.status === "ready" ? "btn-soft btn-error" : "btn-outline"} gap-2`}
-                                  disabled={isUpdating()}
-                                  onClick={() => void toggleStatus(asset.id, asset.status)}
-                                  type="button"
-                                >
-                                  {asset.status === "ready" ? (
-                                    <VolumeX class="h-4 w-4" />
-                                  ) : (
-                                    <Volume2 class="h-4 w-4" />
-                                  )}
-                                  {toggleStatusLabel()}
-                                </button>
-                              </div>
-                            </div>
-                          );
-                        }}
-                      </For>
-                    </div>
-                  )}
-                </Show>
-              </div>
-            </div>
+                  <DataTable
+                    columns={columns}
+                    data={assets()}
+                    emptyTitle="No sounds in the library"
+                    emptyDescription="Upload a goal or win sound to populate the shared library."
+                  />
+                </TableSection>
+              )}
+            </Show>
           </section>
         </Match>
       </Switch>

--- a/src/components/sounds/SoundsPage.tsx
+++ b/src/components/sounds/SoundsPage.tsx
@@ -371,9 +371,6 @@ export default function SoundsPage() {
                       Admin
                     </p>
                     <h1 class="card-title text-2xl">Public sound library</h1>
-                    <p class="text-base-content/70 max-w-2xl text-sm">
-                      Manage the shared goal and win sound pools stored in Supabase Storage.
-                    </p>
                   </div>
                   <div class="text-base-content/70 flex items-center gap-2 text-sm font-medium">
                     <AudioLines class="h-4 w-4" />
@@ -444,12 +441,7 @@ export default function SoundsPage() {
 
                   <div class="rounded-box bg-base-200 flex flex-col gap-4 p-4">
                     <div class="flex items-center justify-between gap-3">
-                      <div>
-                        <h2 class="text-lg font-semibold">Preview</h2>
-                        <p class="text-base-content/70 text-sm">
-                          Validation runs in the browser before anything is uploaded.
-                        </p>
-                      </div>
+                      <h2 class="text-lg font-semibold">Preview</h2>
                       <div class="badge badge-outline">
                         {selectedFile() ? "Ready to review" : "No file selected"}
                       </div>
@@ -544,7 +536,6 @@ export default function SoundsPage() {
                 <TableSection
                   eyebrow="Library"
                   title="Existing sounds"
-                  description="Ready sounds are eligible for playback. Disabled sounds stay in the library but are skipped."
                   stats={
                     <>
                       <span class="badge badge-outline badge-sm gap-2 px-3 py-3">

--- a/src/components/sounds/SoundsPage.tsx
+++ b/src/components/sounds/SoundsPage.tsx
@@ -233,32 +233,37 @@ export default function SoundsPage() {
               </div>
             </div>
 
-            <div class="grid gap-2 text-sm sm:hidden">
+            <div class="grid gap-2 text-sm lg:hidden">
               <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm">
                 <span class="text-base-content/70">
                   Duration {formatDuration(asset.durationMs)}
                 </span>
                 <span class="text-base-content/70">Size {formatBytes(asset.sizeBytes)}</span>
               </div>
-              <audio class="w-full" controls preload="metadata" src={asset.url}>
-                <track
-                  default
-                  kind="captions"
-                  label="No captions available"
-                  src={EMPTY_CAPTIONS_TRACK}
-                  srclang="en"
-                />
-              </audio>
-              <button
-                class={`btn btn-xs min-w-28 ${
-                  asset.status === "ready" ? "btn-soft btn-error" : "btn-outline"
-                }`}
-                disabled={isUpdating()}
-                onClick={() => void toggleStatus(asset.id, asset.status)}
-                type="button"
-              >
-                {getAssetToggleLabel(isUpdating(), asset.status)}
-              </button>
+              <div class="text-base-content/70 truncate text-sm">Source {asset.storagePath}</div>
+              <div class="md:hidden">
+                <audio class="w-full" controls preload="metadata" src={asset.url}>
+                  <track
+                    default
+                    kind="captions"
+                    label="No captions available"
+                    src={EMPTY_CAPTIONS_TRACK}
+                    srclang="en"
+                  />
+                </audio>
+              </div>
+              <div class="md:flex md:justify-start">
+                <button
+                  class={`btn btn-xs min-w-28 ${
+                    asset.status === "ready" ? "btn-soft btn-error" : "btn-outline"
+                  } md:btn-sm`}
+                  disabled={isUpdating()}
+                  onClick={() => void toggleStatus(asset.id, asset.status)}
+                  type="button"
+                >
+                  {getAssetToggleLabel(isUpdating(), asset.status)}
+                </button>
+              </div>
             </div>
           </div>
         );
@@ -301,8 +306,8 @@ export default function SoundsPage() {
       id: "preview",
       header: "Preview",
       meta: {
-        headerClass: "hidden md:table-cell",
-        cellClass: "hidden md:table-cell md:min-w-64",
+        headerClass: "hidden lg:table-cell",
+        cellClass: "hidden lg:table-cell lg:min-w-64",
       },
       cell: (info) => {
         const asset = info.row.original;
@@ -324,8 +329,8 @@ export default function SoundsPage() {
       id: "actions",
       header: "Actions",
       meta: {
-        headerClass: "hidden text-right md:table-cell",
-        cellClass: "hidden w-0 text-right md:table-cell",
+        headerClass: "hidden text-right lg:table-cell",
+        cellClass: "hidden w-0 text-right lg:table-cell",
       },
       cell: (info) => {
         const asset = info.row.original;

--- a/src/components/sounds/SoundsPage.tsx
+++ b/src/components/sounds/SoundsPage.tsx
@@ -241,7 +241,7 @@ export default function SoundsPage() {
                 <span class="text-base-content/70">Size {formatBytes(asset.sizeBytes)}</span>
               </div>
               <div class="text-base-content/70 truncate text-sm">Source {asset.storagePath}</div>
-              <div class="md:hidden">
+              <div class="lg:hidden">
                 <audio class="w-full" controls preload="metadata" src={asset.url}>
                   <track
                     default

--- a/src/components/sounds/SoundsPage.tsx
+++ b/src/components/sounds/SoundsPage.tsx
@@ -37,6 +37,14 @@ function getSoundInitials(name: string) {
     .join("");
 }
 
+function getAssetToggleLabel(isUpdating: boolean, status: SoundAsset["status"]) {
+  if (isUpdating) {
+    return "Saving...";
+  }
+
+  return status === "ready" ? "Disable" : "Enable";
+}
+
 export default function SoundsPage() {
   const [profile] = createResource(getCurrentProfile);
   const [soundAssets, { refetch }] = createResource(
@@ -193,6 +201,7 @@ export default function SoundsPage() {
       header: "Sound",
       cell: (info) => {
         const asset = info.row.original;
+        const isUpdating = () => updatingIds().includes(asset.id);
 
         return (
           <div class="min-w-0 space-y-3">
@@ -244,15 +253,11 @@ export default function SoundsPage() {
                 class={`btn btn-xs min-w-28 ${
                   asset.status === "ready" ? "btn-soft btn-error" : "btn-outline"
                 }`}
-                disabled={updatingIds().includes(asset.id)}
+                disabled={isUpdating()}
                 onClick={() => void toggleStatus(asset.id, asset.status)}
                 type="button"
               >
-                {updatingIds().includes(asset.id)
-                  ? "Saving..."
-                  : asset.status === "ready"
-                    ? "Disable"
-                    : "Enable"}
+                {getAssetToggleLabel(isUpdating(), asset.status)}
               </button>
             </div>
           </div>
@@ -336,7 +341,7 @@ export default function SoundsPage() {
             type="button"
           >
             {asset.status === "ready" ? <VolumeX class="h-4 w-4" /> : <Volume2 class="h-4 w-4" />}
-            {isUpdating() ? "Saving..." : asset.status === "ready" ? "Disable" : "Enable"}
+            {getAssetToggleLabel(isUpdating(), asset.status)}
           </button>
         );
       },

--- a/src/components/teams/Teams.tsx
+++ b/src/components/teams/Teams.tsx
@@ -42,8 +42,8 @@ const columns: ColumnDef<TeamWithMembers>[] = [
             </div>
             <div class="min-w-0">
               <p class="truncate font-semibold">{team.name}</p>
-              <p class="text-base-content/65 text-sm">
-                {memberCount} {memberCount === 1 ? "member" : "members"} ready for match setup.
+              <p class="text-base-content/65 text-sm sm:hidden">
+                {memberCount} {memberCount === 1 ? "member" : "members"}
               </p>
             </div>
           </div>
@@ -161,7 +161,6 @@ export default function Teams(props: RouteSectionProps) {
               <TableSection
                 eyebrow="Lineups"
                 title="Teams"
-                description="Keep custom pairings organized with a layout that can absorb future stats like record and goals scored without reworking the page."
                 stats={
                   <>
                     <span class="badge badge-outline badge-sm gap-2 px-3 py-3">

--- a/src/components/teams/Teams.tsx
+++ b/src/components/teams/Teams.tsx
@@ -170,16 +170,7 @@ export default function Teams(props: RouteSectionProps) {
                   data={resolvedData}
                   emptyTitle="No teams yet"
                   emptyDescription="Create a team to group players for quick match setup."
-                  summaryItems={[
-                    { label: "Teams", value: resolvedData.length },
-                    {
-                      label: "Members",
-                      value: resolvedData.reduce(
-                        (count, team) => count + (team.team_members?.length ?? 0),
-                        0
-                      ),
-                    },
-                  ]}
+                  summaryItems={[{ label: "Teams", value: resolvedData.length }]}
                 />
               </TableSection>
             )}

--- a/src/components/teams/Teams.tsx
+++ b/src/components/teams/Teams.tsx
@@ -3,7 +3,6 @@ import type { RouteSectionProps } from "@solidjs/router";
 import { hasSupabaseConfig } from "~/service/supabaseService.ts";
 import { createResource, createSignal, Show, For } from "solid-js";
 import { ColumnDef } from "@tanstack/solid-table";
-import { Shield, Users } from "lucide-solid";
 import { DataTable } from "~/components/shared/table/DataTable.tsx";
 import { TableSection } from "~/components/shared/table/TableSection.tsx";
 import ConfirmTeamDelete from "./ConfirmDelete";
@@ -56,7 +55,7 @@ const columns: ColumnDef<TeamWithMembers>[] = [
               <div class="flex flex-wrap gap-1.5">
                 <For each={team.team_members}>
                   {(member) => (
-                    <span class="badge badge-outline badge-sm">
+                    <span class="badge badge-outline px-3 py-2 text-sm font-medium">
                       {member.players?.name ?? "Unknown"}
                     </span>
                   )}
@@ -98,7 +97,7 @@ const columns: ColumnDef<TeamWithMembers>[] = [
           <div class="flex flex-wrap gap-1.5">
             <For each={members}>
               {(member) => (
-                <span class="badge badge-outline badge-sm">
+                <span class="badge badge-outline px-3 py-2 text-sm font-medium">
                   {member.players?.name ?? "Unknown"}
                 </span>
               )}
@@ -147,7 +146,7 @@ export default function Teams(props: RouteSectionProps) {
       }
     >
       <TeamListContext.Provider value={{ refetchTeams: refetch }}>
-        <div class="px-4 py-4 sm:px-6">
+        <div class="mx-auto w-full max-w-3xl px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
           <Show
             when={data()}
             keyed
@@ -159,27 +158,10 @@ export default function Teams(props: RouteSectionProps) {
           >
             {(resolvedData) => (
               <TableSection
-                eyebrow="Lineups"
                 title="Teams"
-                stats={
-                  <>
-                    <span class="badge badge-outline badge-sm gap-2 px-3 py-3">
-                      <Shield class="h-3.5 w-3.5" />
-                      {resolvedData.length} {resolvedData.length === 1 ? "team" : "teams"}
-                    </span>
-                    <span class="badge badge-outline badge-sm gap-2 px-3 py-3">
-                      <Users class="h-3.5 w-3.5" />
-                      {resolvedData.reduce(
-                        (count, team) => count + (team.team_members?.length ?? 0),
-                        0
-                      )}{" "}
-                      roster slots
-                    </span>
-                  </>
-                }
                 actions={
-                  <A class="btn btn-primary btn-sm sm:btn-md min-w-40" href="/teams/new">
-                    Create New Team
+                  <A class="btn btn-primary btn-sm sm:btn-md w-full sm:min-w-40" href="/teams/new">
+                    Create team
                   </A>
                 }
               >
@@ -188,6 +170,16 @@ export default function Teams(props: RouteSectionProps) {
                   data={resolvedData}
                   emptyTitle="No teams yet"
                   emptyDescription="Create a team to group players for quick match setup."
+                  summaryItems={[
+                    { label: "Teams", value: resolvedData.length },
+                    {
+                      label: "Members",
+                      value: resolvedData.reduce(
+                        (count, team) => count + (team.team_members?.length ?? 0),
+                        0
+                      ),
+                    },
+                  ]}
                 />
               </TableSection>
             )}

--- a/src/components/teams/Teams.tsx
+++ b/src/components/teams/Teams.tsx
@@ -3,7 +3,9 @@ import type { RouteSectionProps } from "@solidjs/router";
 import { hasSupabaseConfig } from "~/service/supabaseService.ts";
 import { createResource, createSignal, Show, For } from "solid-js";
 import { ColumnDef } from "@tanstack/solid-table";
+import { Shield, Users } from "lucide-solid";
 import { DataTable } from "~/components/shared/table/DataTable.tsx";
+import { TableSection } from "~/components/shared/table/TableSection.tsx";
 import ConfirmTeamDelete from "./ConfirmDelete";
 import { getTeamsWithMembers, TeamWithMembers } from "~/service/teamService";
 import { TeamListContext } from "./TeamListContext";
@@ -11,45 +13,121 @@ import { TeamListContext } from "./TeamListContext";
 const [showConfirm, setShowConfirm] = createSignal(false);
 const [teamToDelete, setTeamToDelete] = createSignal<TeamWithMembers | null>(null);
 
+const openDeleteConfirm = (team: TeamWithMembers) => {
+  setTeamToDelete(team);
+  setShowConfirm(true);
+};
+
+const getTeamInitials = (name: string) =>
+  name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+
 const columns: ColumnDef<TeamWithMembers>[] = [
   {
-    header: "Actions",
+    accessorKey: "name",
+    header: "Team",
     cell: (info) => {
       const team = info.row.original;
+      const memberCount = team.team_members?.length ?? 0;
+
       return (
-        <div class="flex gap-2">
-          <A class="btn btn-outline btn-sm min-w-20" href={`/teams/edit/${team.id}`}>
-            Edit
-          </A>
-          <button
-            class="btn btn-soft btn-error btn-sm min-w-20"
-            onClick={() => {
-              setTeamToDelete(team);
-              setShowConfirm(true);
-            }}
-          >
-            Delete
-          </button>
+        <div class="min-w-0 space-y-3">
+          <div class="flex min-w-0 items-center gap-3">
+            <div class="bg-secondary/12 text-secondary flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold">
+              {getTeamInitials(team.name)}
+            </div>
+            <div class="min-w-0">
+              <p class="truncate font-semibold">{team.name}</p>
+              <p class="text-base-content/65 text-sm">
+                {memberCount} {memberCount === 1 ? "member" : "members"} ready for match setup.
+              </p>
+            </div>
+          </div>
+
+          <div class="space-y-2 sm:hidden">
+            <Show
+              when={team.team_members?.length}
+              fallback={<span class="text-base-content/60 text-sm">No members assigned yet.</span>}
+            >
+              <div class="flex flex-wrap gap-1.5">
+                <For each={team.team_members}>
+                  {(member) => (
+                    <span class="badge badge-outline badge-sm">
+                      {member.players?.name ?? "Unknown"}
+                    </span>
+                  )}
+                </For>
+              </div>
+            </Show>
+
+            <div class="flex flex-wrap gap-2">
+              <A class="btn btn-outline btn-xs min-w-20" href={`/teams/edit/${team.id}`}>
+                Edit
+              </A>
+              <button
+                class="btn btn-soft btn-error btn-xs min-w-20"
+                onClick={() => openDeleteConfirm(team)}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
         </div>
       );
     },
   },
   {
-    accessorKey: "name",
-    header: "Name",
-  },
-  {
     header: "Members",
+    meta: {
+      headerClass: "hidden sm:table-cell",
+      cellClass: "hidden sm:table-cell",
+    },
     cell: (info) => {
       const team = info.row.original;
       const members = team.team_members ?? [];
+
       return (
-        <div class="flex flex-wrap gap-1">
-          <For each={members}>
-            {(member) => (
-              <span class="badge badge-sm badge-outline">{member.players?.name ?? "Unknown"}</span>
-            )}
-          </For>
+        <Show
+          when={members.length > 0}
+          fallback={<span class="text-base-content/60 text-sm">No members assigned yet.</span>}
+        >
+          <div class="flex flex-wrap gap-1.5">
+            <For each={members}>
+              {(member) => (
+                <span class="badge badge-outline badge-sm">
+                  {member.players?.name ?? "Unknown"}
+                </span>
+              )}
+            </For>
+          </div>
+        </Show>
+      );
+    },
+  },
+  {
+    id: "actions",
+    header: "Actions",
+    meta: {
+      headerClass: "hidden text-right sm:table-cell",
+      cellClass: "hidden w-0 text-right sm:table-cell",
+    },
+    cell: (info) => {
+      const team = info.row.original;
+      return (
+        <div class="flex justify-end gap-2">
+          <A class="btn btn-outline btn-sm min-w-20" href={`/teams/edit/${team.id}`}>
+            Edit
+          </A>
+          <button
+            class="btn btn-soft btn-error btn-sm min-w-20"
+            onClick={() => openDeleteConfirm(team)}
+          >
+            Delete
+          </button>
         </div>
       );
     },
@@ -69,26 +147,52 @@ export default function Teams(props: RouteSectionProps) {
       }
     >
       <TeamListContext.Provider value={{ refetchTeams: refetch }}>
-        <div class="px-4 py-2">
-          <div class="text-lg">Teams</div>
-          <div class="mx-auto w-full">
-            <Show
-              when={data()}
-              keyed
-              fallback={
-                <div class="flex h-full items-center justify-center">
-                  <span class="loading loading-spinner loading-xl" />
-                </div>
-              }
-            >
-              {(resolvedData) => <DataTable columns={columns} data={resolvedData} />}
-            </Show>
-          </div>
-          <div class="mt-4 text-center">
-            <A class="btn btn-primary btn-sm sm:btn-md min-w-40" href="/teams/new">
-              Create New Team
-            </A>
-          </div>
+        <div class="px-4 py-4 sm:px-6">
+          <Show
+            when={data()}
+            keyed
+            fallback={
+              <div class="flex h-full items-center justify-center">
+                <span class="loading loading-spinner loading-xl" />
+              </div>
+            }
+          >
+            {(resolvedData) => (
+              <TableSection
+                eyebrow="Lineups"
+                title="Teams"
+                description="Keep custom pairings organized with a layout that can absorb future stats like record and goals scored without reworking the page."
+                stats={
+                  <>
+                    <span class="badge badge-outline badge-sm gap-2 px-3 py-3">
+                      <Shield class="h-3.5 w-3.5" />
+                      {resolvedData.length} {resolvedData.length === 1 ? "team" : "teams"}
+                    </span>
+                    <span class="badge badge-outline badge-sm gap-2 px-3 py-3">
+                      <Users class="h-3.5 w-3.5" />
+                      {resolvedData.reduce(
+                        (count, team) => count + (team.team_members?.length ?? 0),
+                        0
+                      )}{" "}
+                      roster slots
+                    </span>
+                  </>
+                }
+                actions={
+                  <A class="btn btn-primary btn-sm sm:btn-md min-w-40" href="/teams/new">
+                    Create New Team
+                  </A>
+                }
+              >
+                <DataTable
+                  columns={columns}
+                  data={resolvedData}
+                  emptyTitle="No teams yet"
+                  emptyDescription="Create a team to group players for quick match setup."
+                />
+              </TableSection>
+            )}
+          </Show>
         </div>
 
         {props.children}

--- a/src/components/teams/Teams.tsx
+++ b/src/components/teams/Teams.tsx
@@ -146,7 +146,7 @@ export default function Teams(props: RouteSectionProps) {
       }
     >
       <TeamListContext.Provider value={{ refetchTeams: refetch }}>
-        <div class="mx-auto w-full max-w-3xl px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
+        <div class="mx-auto w-full max-w-[min(96vw,1400px)] px-4 py-4 sm:px-5 sm:py-5 lg:px-6">
           <Show
             when={data()}
             keyed

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -15,7 +15,7 @@ project_id = "foosball-tracker"
 [api]
 enabled = true
 # Port to use for the API URL.
-port = 54321
+port = 15421
 # Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
 # endpoints. `public` and `graphql_public` schemas are included by default.
 schemas = ["public", "graphql_public"]
@@ -34,7 +34,7 @@ enabled = false
 
 [db]
 # Port to use for the local database URL.
-port = 54322
+port = 15422
 # Port used by db diff command to initialize the shadow database.
 shadow_port = 54320
 # Maximum amount of time to wait for health check when starting the local database.
@@ -96,7 +96,7 @@ enabled = true
 [studio]
 enabled = true
 # Port to use for Supabase Studio.
-port = 54323
+port = 15423
 # External URL of the API server that frontend connects to.
 api_url = "http://127.0.0.1"
 # OpenAI API Key to use for Supabase AI in the Supabase Studio.
@@ -107,7 +107,7 @@ openai_api_key = "env(OPENAI_API_KEY)"
 [inbucket]
 enabled = true
 # Port to use for the email testing server web interface.
-port = 54324
+port = 15424
 # Uncomment to expose additional ports for testing user applications that send emails.
 # smtp_port = 54325
 # pop3_port = 54326


### PR DESCRIPTION
Closes #13

## Summary
- redesign the shared table shell to use a cleaner DaisyUI card/table presentation
- refresh Players, Teams, Sounds, and Leaderboard with consistent section headers, responsive row layouts, and shared table styling
- improve table and grid actions so key controls stay visible on mobile instead of hiding behind horizontal scrolling

## Verification
- pnpm lint
- pnpm local:setup
- pnpm auth:local -- --headless
- pnpm test:e2e
- pnpm test:e2e:auth
- pnpm proof:capture -- --name issue-13-players --route /players
- pnpm proof:capture -- --name issue-13-teams --route /teams
- pnpm proof:capture -- --name issue-13-sounds --route /sounds
- pnpm proof:capture -- --name issue-13-leaderboard --route /leaderboard
- pnpm proof:publish
